### PR TITLE
chore: symlink AGENTS.md to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` as a symlink to `CLAUDE.md` so agent frameworks looking for either filename find the agentic knowledge base

## Test plan
- [x] Symlink resolves correctly (`cat AGENTS.md` shows CLAUDE.md content)
- [x] No impact on existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)