### PR TITLE
fix: improve cloud-setup robustness for gh and sqlite

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -95,7 +95,7 @@ install_gh() {
 # --- Persist PATH for subsequent Bash tool calls (idempotent) ---
 persist_env() {
   if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-    # Remove any existing PATH/GOPATH/GOPROXY lines to avoid unbounded growth.
+    # Remove any existing PATH/GOPATH/GOPROXY/GOSUMDB lines to avoid unbounded growth.
     if [ -f "${CLAUDE_ENV_FILE}" ]; then
       grep -vE '^(PATH=|GOPATH=|GOPROXY=|GOSUMDB=)' "${CLAUDE_ENV_FILE}" > "${CLAUDE_ENV_FILE}.tmp" || true
       mv "${CLAUDE_ENV_FILE}.tmp" "${CLAUDE_ENV_FILE}"


### PR DESCRIPTION
## Summary

Fixes DNS resolution issue preventing Go module downloads in Claude Code Cloud.

## Root Cause

The cloud environment has DNS resolution failing to IPv6 localhost (`[::1]:53`), causing:
```
dial tcp: lookup storage.googleapis.com on [::1]:53: read udp [::1]:57632->[::1]:53: read: connection refused
```

This blocks `go mod download` from fetching modules via Google's proxy.

## Solution

Bypass the module proxy entirely:
- Set `GOPROXY=direct` — download directly from source repos (github.com, gitlab.com)
- Set `GOSUMDB=off` — skip checksum database (also affected by DNS)
- Persist these env vars for subsequent Bash tool calls

This allows Go to fetch modules directly from their source repositories instead of going through storage.googleapis.com.

## Additional Fix

Fixed gh CLI keyring download to use temp files instead of pipes (avoids gpg permission issues).

## Trade-offs

- **Pro**: Works around DNS issues, no external dependencies needed
- **Con**: Skips checksum verification (GOSUMDB=off) — acceptable for trusted repos
- **Con**: Slightly slower than proxy (no caching benefits)

## Test plan

- [x] gh CLI installs successfully with temp file approach
- [ ] Go modules download successfully with GOPROXY=direct (cloud test required)
- [ ] Build completes without DNS errors (cloud test required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)