### PR TITLE
Add --help flag support to all shell functions

### DIFF
--- a/internal/shell/functions.go
+++ b/internal/shell/functions.go
@@ -17,14 +17,44 @@ func Functions() []ShellFunc {
 		{
 			Name: "mkcd",
 			Desc: "Create a directory and cd into it",
-			Bash: `mkcd() { mkdir -p "$1" && cd "$1"; }`,
-			Zsh:  `mkcd() { mkdir -p "$1" && cd "$1"; }`,
-			Fish: `function mkcd; mkdir -p $argv[1]; and cd $argv[1]; end`,
+			Bash: `mkcd() {
+  if [ "$1" = "--help" ]; then
+    echo "mkcd — Create a directory and cd into it"
+    echo "Usage: mkcd <dir>"
+    echo "Example: mkcd my-project"
+    return 0
+  fi
+  mkdir -p "$1" && cd "$1"
+}`,
+			Zsh: `mkcd() {
+  if [[ "$1" == "--help" ]]; then
+    echo "mkcd — Create a directory and cd into it"
+    echo "Usage: mkcd <dir>"
+    echo "Example: mkcd my-project"
+    return 0
+  fi
+  mkdir -p "$1" && cd "$1"
+}`,
+			Fish: `function mkcd
+  if test "$argv[1]" = "--help"
+    echo "mkcd — Create a directory and cd into it"
+    echo "Usage: mkcd <dir>"
+    echo "Example: mkcd my-project"
+    return 0
+  end
+  mkdir -p $argv[1]; and cd $argv[1]
+end`,
 		},
 		{
 			Name: "extract",
 			Desc: "Extract any common archive format",
 			Bash: `extract() {
+  if [ "$1" = "--help" ]; then
+    echo "extract — Extract any common archive format"
+    echo "Usage: extract <file>"
+    echo "Example: extract archive.tar.gz"
+    return 0
+  fi
   if [ ! -f "$1" ]; then echo "extract: '$1' not found" >&2; return 1; fi
   case "$1" in
     *.tar.bz2) tar xjf "$1" ;;
@@ -43,6 +73,12 @@ func Functions() []ShellFunc {
   esac
 }`,
 			Zsh: `extract() {
+  if [[ "$1" == "--help" ]]; then
+    echo "extract — Extract any common archive format"
+    echo "Usage: extract <file>"
+    echo "Example: extract archive.tar.gz"
+    return 0
+  fi
   if [[ ! -f "$1" ]]; then echo "extract: '$1' not found" >&2; return 1; fi
   case "$1" in
     *.tar.bz2) tar xjf "$1" ;;
@@ -61,6 +97,12 @@ func Functions() []ShellFunc {
   esac
 }`,
 			Fish: `function extract
+  if test "$argv[1]" = "--help"
+    echo "extract — Extract any common archive format"
+    echo "Usage: extract <file>"
+    echo "Example: extract archive.tar.gz"
+    return 0
+  end
   if not test -f $argv[1]
     echo "extract: '$argv[1]' not found" >&2; return 1
   end
@@ -84,37 +126,160 @@ end`,
 		{
 			Name: "ports",
 			Desc: "Show listening network ports",
-			Bash: `ports() { lsof -iTCP -sTCP:LISTEN -P -n 2>/dev/null || ss -tlnp 2>/dev/null; }`,
-			Zsh:  `ports() { lsof -iTCP -sTCP:LISTEN -P -n 2>/dev/null || ss -tlnp 2>/dev/null; }`,
-			Fish: `function ports; lsof -iTCP -sTCP:LISTEN -P -n 2>/dev/null; or ss -tlnp 2>/dev/null; end`,
+			Bash: `ports() {
+  if [ "$1" = "--help" ]; then
+    echo "ports — Show listening network ports"
+    echo "Usage: ports"
+    echo "Example: ports"
+    return 0
+  fi
+  lsof -iTCP -sTCP:LISTEN -P -n 2>/dev/null || ss -tlnp 2>/dev/null
+}`,
+			Zsh: `ports() {
+  if [[ "$1" == "--help" ]]; then
+    echo "ports — Show listening network ports"
+    echo "Usage: ports"
+    echo "Example: ports"
+    return 0
+  fi
+  lsof -iTCP -sTCP:LISTEN -P -n 2>/dev/null || ss -tlnp 2>/dev/null
+}`,
+			Fish: `function ports
+  if test "$argv[1]" = "--help"
+    echo "ports — Show listening network ports"
+    echo "Usage: ports"
+    echo "Example: ports"
+    return 0
+  end
+  lsof -iTCP -sTCP:LISTEN -P -n 2>/dev/null; or ss -tlnp 2>/dev/null
+end`,
 		},
 		{
 			Name: "gitroot",
 			Desc: "cd to the root of the current git repo",
-			Bash: `gitroot() { cd "$(git rev-parse --show-toplevel 2>/dev/null)" || echo "not in a git repo" >&2; }`,
-			Zsh:  `gitroot() { cd "$(git rev-parse --show-toplevel 2>/dev/null)" || echo "not in a git repo" >&2; }`,
-			Fish: `function gitroot; cd (git rev-parse --show-toplevel 2>/dev/null); or echo "not in a git repo" >&2; end`,
+			Bash: `gitroot() {
+  if [ "$1" = "--help" ]; then
+    echo "gitroot — cd to the root of the current git repo"
+    echo "Usage: gitroot"
+    echo "Example: gitroot"
+    return 0
+  fi
+  cd "$(git rev-parse --show-toplevel 2>/dev/null)" || echo "not in a git repo" >&2
+}`,
+			Zsh: `gitroot() {
+  if [[ "$1" == "--help" ]]; then
+    echo "gitroot — cd to the root of the current git repo"
+    echo "Usage: gitroot"
+    echo "Example: gitroot"
+    return 0
+  fi
+  cd "$(git rev-parse --show-toplevel 2>/dev/null)" || echo "not in a git repo" >&2
+}`,
+			Fish: `function gitroot
+  if test "$argv[1]" = "--help"
+    echo "gitroot — cd to the root of the current git repo"
+    echo "Usage: gitroot"
+    echo "Example: gitroot"
+    return 0
+  end
+  cd (git rev-parse --show-toplevel 2>/dev/null); or echo "not in a git repo" >&2
+end`,
 		},
 		{
 			Name: "serve",
 			Desc: "Start a quick HTTP server in the current directory",
-			Bash: `serve() { local port="${1:-8000}"; python3 -m http.server "$port" 2>/dev/null || python -m SimpleHTTPServer "$port"; }`,
-			Zsh:  `serve() { local port="${1:-8000}"; python3 -m http.server "$port" 2>/dev/null || python -m SimpleHTTPServer "$port"; }`,
-			Fish: `function serve; set -l port (test (count $argv) -gt 0; and echo $argv[1]; or echo 8000); python3 -m http.server $port 2>/dev/null; or python -m SimpleHTTPServer $port; end`,
+			Bash: `serve() {
+  if [ "$1" = "--help" ]; then
+    echo "serve — Start a quick HTTP server in the current directory"
+    echo "Usage: serve [port]"
+    echo "Example: serve 3000"
+    return 0
+  fi
+  local port="${1:-8000}"
+  python3 -m http.server "$port" 2>/dev/null || python -m SimpleHTTPServer "$port"
+}`,
+			Zsh: `serve() {
+  if [[ "$1" == "--help" ]]; then
+    echo "serve — Start a quick HTTP server in the current directory"
+    echo "Usage: serve [port]"
+    echo "Example: serve 3000"
+    return 0
+  fi
+  local port="${1:-8000}"
+  python3 -m http.server "$port" 2>/dev/null || python -m SimpleHTTPServer "$port"
+}`,
+			Fish: `function serve
+  if test "$argv[1]" = "--help"
+    echo "serve — Start a quick HTTP server in the current directory"
+    echo "Usage: serve [port]"
+    echo "Example: serve 3000"
+    return 0
+  end
+  set -l port (test (count $argv) -gt 0; and echo $argv[1]; or echo 8000)
+  python3 -m http.server $port 2>/dev/null; or python -m SimpleHTTPServer $port
+end`,
 		},
 		{
 			Name: "backup",
 			Desc: "Create a timestamped backup copy of a file",
-			Bash: `backup() { cp "$1" "$1.bak.$(date +%Y%m%d_%H%M%S)"; }`,
-			Zsh:  `backup() { cp "$1" "$1.bak.$(date +%Y%m%d_%H%M%S)"; }`,
-			Fish: `function backup; cp $argv[1] $argv[1].bak.(date +%Y%m%d_%H%M%S); end`,
+			Bash: `backup() {
+  if [ "$1" = "--help" ]; then
+    echo "backup — Create a timestamped backup copy of a file"
+    echo "Usage: backup <file>"
+    echo "Example: backup config.yaml"
+    return 0
+  fi
+  cp "$1" "$1.bak.$(date +%Y%m%d_%H%M%S)"
+}`,
+			Zsh: `backup() {
+  if [[ "$1" == "--help" ]]; then
+    echo "backup — Create a timestamped backup copy of a file"
+    echo "Usage: backup <file>"
+    echo "Example: backup config.yaml"
+    return 0
+  fi
+  cp "$1" "$1.bak.$(date +%Y%m%d_%H%M%S)"
+}`,
+			Fish: `function backup
+  if test "$argv[1]" = "--help"
+    echo "backup — Create a timestamped backup copy of a file"
+    echo "Usage: backup <file>"
+    echo "Example: backup config.yaml"
+    return 0
+  end
+  cp $argv[1] $argv[1].bak.(date +%Y%m%d_%H%M%S)
+end`,
 		},
 		{
 			Name: "tre",
 			Desc: "tree with sensible defaults (2 levels, ignore hidden/vendor)",
-			Bash: `tre() { tree -L "${1:-2}" -I 'node_modules|vendor|.git|__pycache__|.venv' --dirsfirst; }`,
-			Zsh:  `tre() { tree -L "${1:-2}" -I 'node_modules|vendor|.git|__pycache__|.venv' --dirsfirst; }`,
-			Fish: `function tre; tree -L (test (count $argv) -gt 0; and echo $argv[1]; or echo 2) -I 'node_modules|vendor|.git|__pycache__|.venv' --dirsfirst; end`,
+			Bash: `tre() {
+  if [ "$1" = "--help" ]; then
+    echo "tre — tree with sensible defaults (2 levels, ignore hidden/vendor)"
+    echo "Usage: tre [depth]"
+    echo "Example: tre 3"
+    return 0
+  fi
+  tree -L "${1:-2}" -I 'node_modules|vendor|.git|__pycache__|.venv' --dirsfirst
+}`,
+			Zsh: `tre() {
+  if [[ "$1" == "--help" ]]; then
+    echo "tre — tree with sensible defaults (2 levels, ignore hidden/vendor)"
+    echo "Usage: tre [depth]"
+    echo "Example: tre 3"
+    return 0
+  fi
+  tree -L "${1:-2}" -I 'node_modules|vendor|.git|__pycache__|.venv' --dirsfirst
+}`,
+			Fish: `function tre
+  if test "$argv[1]" = "--help"
+    echo "tre — tree with sensible defaults (2 levels, ignore hidden/vendor)"
+    echo "Usage: tre [depth]"
+    echo "Example: tre 3"
+    return 0
+  end
+  tree -L (test (count $argv) -gt 0; and echo $argv[1]; or echo 2) -I 'node_modules|vendor|.git|__pycache__|.venv' --dirsfirst
+end`,
 		},
 	}
 }

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -185,6 +185,107 @@ func TestStarshipConfig(t *testing.T) {
 	}
 }
 
+func TestFunctionsHelpFlag(t *testing.T) {
+	funcs := Functions()
+
+	for _, fn := range funcs {
+		// Each function's implementation should contain --help handling.
+		t.Run(fn.Name+"/bash", func(t *testing.T) {
+			if !strings.Contains(fn.Bash, `"--help"`) {
+				t.Errorf("bash %s missing --help check", fn.Name)
+			}
+			// Help output should include description.
+			if !strings.Contains(fn.Bash, fn.Name+" — ") {
+				t.Errorf("bash %s --help missing description line", fn.Name)
+			}
+			// Help output should include usage.
+			if !strings.Contains(fn.Bash, "Usage: "+fn.Name) {
+				t.Errorf("bash %s --help missing usage line", fn.Name)
+			}
+			// Help output should include example.
+			if !strings.Contains(fn.Bash, "Example: "+fn.Name) {
+				t.Errorf("bash %s --help missing example line", fn.Name)
+			}
+		})
+
+		t.Run(fn.Name+"/zsh", func(t *testing.T) {
+			if !strings.Contains(fn.Zsh, `"--help"`) {
+				t.Errorf("zsh %s missing --help check", fn.Name)
+			}
+			if !strings.Contains(fn.Zsh, fn.Name+" — ") {
+				t.Errorf("zsh %s --help missing description line", fn.Name)
+			}
+			if !strings.Contains(fn.Zsh, "Usage: "+fn.Name) {
+				t.Errorf("zsh %s --help missing usage line", fn.Name)
+			}
+			if !strings.Contains(fn.Zsh, "Example: "+fn.Name) {
+				t.Errorf("zsh %s --help missing example line", fn.Name)
+			}
+		})
+
+		t.Run(fn.Name+"/fish", func(t *testing.T) {
+			if !strings.Contains(fn.Fish, `"--help"`) {
+				t.Errorf("fish %s missing --help check", fn.Name)
+			}
+			if !strings.Contains(fn.Fish, fn.Name+" — ") {
+				t.Errorf("fish %s --help missing description line", fn.Name)
+			}
+			if !strings.Contains(fn.Fish, "Usage: "+fn.Name) {
+				t.Errorf("fish %s --help missing usage line", fn.Name)
+			}
+			if !strings.Contains(fn.Fish, "Example: "+fn.Name) {
+				t.Errorf("fish %s --help missing example line", fn.Name)
+			}
+		})
+	}
+}
+
+func TestFunctionsScriptContainsHelp(t *testing.T) {
+	shells := []string{Bash, Zsh, Fish}
+	for _, sh := range shells {
+		t.Run(sh, func(t *testing.T) {
+			script, err := FunctionsScript(sh)
+			if err != nil {
+				t.Fatalf("FunctionsScript(%q) error: %v", sh, err)
+			}
+
+			// Every function should have --help handling in the generated script.
+			for _, fn := range Functions() {
+				if !strings.Contains(script, "Usage: "+fn.Name) {
+					t.Errorf("generated %s script for %s missing help usage line", sh, fn.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestFunctionsHelpShellSyntax(t *testing.T) {
+	funcs := Functions()
+
+	for _, fn := range funcs {
+		// Bash should use [ ... ] for --help check.
+		t.Run(fn.Name+"/bash_syntax", func(t *testing.T) {
+			if !strings.Contains(fn.Bash, `[ "$1" = "--help" ]`) {
+				t.Errorf("bash %s should use [ ] for --help check", fn.Name)
+			}
+		})
+
+		// Zsh should use [[ ... ]] for --help check.
+		t.Run(fn.Name+"/zsh_syntax", func(t *testing.T) {
+			if !strings.Contains(fn.Zsh, `[[ "$1" == "--help" ]]`) {
+				t.Errorf("zsh %s should use [[ ]] for --help check", fn.Name)
+			}
+		})
+
+		// Fish should use test for --help check.
+		t.Run(fn.Name+"/fish_syntax", func(t *testing.T) {
+			if !strings.Contains(fn.Fish, `test "$argv[1]" = "--help"`) {
+				t.Errorf("fish %s should use test for --help check", fn.Name)
+			}
+		})
+	}
+}
+
 func TestInitScriptBashAliasFormat(t *testing.T) {
 	script, _ := InitScript(Bash)
 	// Bash aliases use = without spaces.


### PR DESCRIPTION
## Summary

Add built-in `--help` flag support to all shell utility functions (mkcd, extract, ports, gitroot, serve, backup, tre) across Bash, Zsh, and Fish shells. Each function now displays usage information and examples when called with `--help`.

## Changes

- Expanded all shell function implementations to include `--help` flag handling with shell-appropriate syntax:
  - Bash: Uses `[ "$1" = "--help" ]` for conditional checks
  - Zsh: Uses `[[ "$1" == "--help" ]]` for conditional checks
  - Fish: Uses `test "$argv[1]" = "--help"` for conditional checks
- Each function's help output includes:
  - Function name with description (em-dash format)
  - Usage line with function name and arguments
  - Example invocation
- Reformatted function definitions from single-line to multi-line for readability
- Added comprehensive test coverage:
  - `TestFunctionsHelpFlag`: Validates all functions contain proper `--help` handling and help text structure
  - `TestFunctionsScriptContainsHelp`: Ensures generated shell scripts include help documentation
  - `TestFunctionsHelpShellSyntax`: Verifies shell-specific syntax is correct for each implementation

## Test plan

- [x] New unit tests added and passing (`TestFunctionsHelpFlag`, `TestFunctionsScriptContainsHelp`, `TestFunctionsHelpShellSyntax`)
- [x] Existing tests continue to pass
- [x] All shell functions maintain backward compatibility (original functionality unchanged)

## Type

- [x] Feature

https://claude.ai/code/session_01AMco9ts2jHxC4pfTzQHCuV