### PR TITLE
fix: allow github-actions bot to trigger claude-code-action

### DIFF
--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -73,6 +73,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions[bot]"
           prompt: |
             You are implementing a feature for the mine CLI tool.
 

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -100,6 +100,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions[bot]"
           prompt: |
             You are fixing review feedback on a PR for the mine CLI tool.
 


### PR DESCRIPTION
## Summary

The autodev-dispatch workflow triggers autodev-implement via `workflow_dispatch` as `github-actions[bot]`. The `claude-code-action@v1` rejects non-human actors by default. This adds `allowed_bots: "github-actions[bot]"` to both agent execution steps.

Discovered during first live test of the autodev pipeline (issue #54).

## Test Plan

- [ ] CI passes
- [ ] Re-trigger `autodev-dispatch` for issue #54 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)