### PR TITLE
fix: skip permissions check for autodev agent in CI

### DIFF
--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -88,7 +88,7 @@ jobs:
             ## Issue #${{ inputs.issue_number }}: ${{ steps.prep.outputs.title }}
 
             ${{ env.ISSUE_BODY }}
-          claude_args: "--max-turns 25"
+          claude_args: "--max-turns 25 --dangerously-skip-permissions"
       # ============================================================
 
       - name: Revert protected file changes

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -115,7 +115,7 @@ jobs:
             ## Review Feedback to Address
 
             ${{ env.REVIEW_FEEDBACK }}
-          claude_args: "--max-turns 15"
+          claude_args: "--max-turns 15 --dangerously-skip-permissions"
       # ============================================================
 
       - name: Revert protected file changes


### PR DESCRIPTION
## Summary

The autodev agent runs in an ephemeral CI container — `--dangerously-skip-permissions` is safe here and avoids having to enumerate every allowed tool. Without this, all Write/Edit calls are denied and the agent burns its entire turn limit retrying the same operation.

Discovered during second live test of autodev pipeline (issue #54).

## Test Plan

- [ ] CI passes
- [ ] Re-trigger `autodev-dispatch` for issue #54 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)