### PR TITLE
fix: restore git push credentials after agent execution

### DIFF
--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -110,9 +110,12 @@ jobs:
 
       - name: Commit and push
         if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git add -A
           git commit -m "feat: implement #${{ inputs.issue_number }}" || true
           git push -u origin "${{ steps.prep.outputs.branch }}"

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -137,9 +137,12 @@ jobs:
 
       - name: Commit and push fixes
         if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git add -A
           git commit -m "fix: address review feedback (iteration ${{ steps.iteration.outputs.next }})"
           git push


### PR DESCRIPTION
## Summary

The `claude-code-action` overrides git credentials during its run, causing subsequent `git push` to fail with `Invalid username or token`. Fix by explicitly re-setting the remote URL with `GITHUB_TOKEN` before pushing in both autodev workflows.

Third issue discovered during live testing of autodev pipeline (issue #54).

## Test Plan

- [ ] CI passes
- [ ] Re-trigger `autodev-dispatch` for issue #54 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)