### PR TITLE
fix: remove unsupported --json flag from gh pr create

### DIFF
--- a/scripts/autodev/open-pr.sh
+++ b/scripts/autodev/open-pr.sh
@@ -20,7 +20,7 @@ ISSUE_TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
 
 # ── Create PR ──────────────────────────────────────────────────────
 
-PR_JSON=$(gh pr create \
+PR_URL=$(gh pr create \
     --repo "$AUTODEV_REPO" \
     --head "$BRANCH_NAME" \
     --base "$AUTODEV_BASE_BRANCH" \
@@ -44,11 +44,9 @@ See commits on this branch for implementation details.
 <!-- autodev-state: {"iteration": 0} -->
 EOF
 )" \
-    --label "$AUTODEV_LABEL_AUTODEV" \
-    --json number,url)
+    --label "$AUTODEV_LABEL_AUTODEV")
 
-PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-PR_URL=$(echo "$PR_JSON" | jq -r '.url')
+PR_NUMBER=$(gh pr list --repo "$AUTODEV_REPO" --head "$BRANCH_NAME" --json number --jq '.[0].number')
 
 autodev_info "Created PR: $PR_URL"
 


### PR DESCRIPTION
## Summary

The CI runner's `gh` CLI doesn't support `--json` on `gh pr create` (that flag was added in a newer version). The agent ran successfully and pushed code, but PR creation failed. Fix by using the plain URL output from `gh pr create` and querying the PR number separately via `gh pr list`.

Fourth issue discovered during live testing of autodev pipeline (issue #54).

## Test Plan

- [ ] CI passes
- [ ] Re-trigger `autodev-dispatch` for issue #54 after merge