### PR TITLE
fix: close/reopen PR to trigger CI after autodev push

### DIFF
--- a/scripts/autodev/open-pr.sh
+++ b/scripts/autodev/open-pr.sh
@@ -50,6 +50,16 @@ PR_NUMBER=$(gh pr list --repo "$AUTODEV_REPO" --head "$BRANCH_NAME" --json numbe
 
 autodev_info "Created PR: $PR_URL"
 
+# ── Trigger CI ─────────────────────────────────────────────────────
+# Pushes by GITHUB_TOKEN don't trigger downstream workflows (GitHub
+# security policy). Close/reopen the PR to fire the pull_request event
+# which triggers CI and code review.
+
+gh pr close "$PR_NUMBER" --repo "$AUTODEV_REPO"
+gh pr reopen "$PR_NUMBER" --repo "$AUTODEV_REPO"
+
+autodev_info "Closed/reopened PR #$PR_NUMBER to trigger CI"
+
 # ── Enable auto-merge ──────────────────────────────────────────────
 
 gh pr merge "$PR_NUMBER" --repo "$AUTODEV_REPO" --squash --auto


### PR DESCRIPTION
## Summary

Pushes by `GITHUB_TOKEN` don't trigger downstream workflows (GitHub security policy). This adds a close/reopen cycle in `open-pr.sh` to fire the `pull_request` event, which triggers CI and code review.

Discovered during live testing — PR #59 was created but CI never ran until manually close/reopened.

## Test Plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)