### PR TITLE
fix: enable Claude review posting and remove auto-merge

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,11 +133,12 @@ Three workflows form a loop:
 1. **`autodev-dispatch`** — Runs on a 4-hour cron (or manual trigger). Picks the oldest
    `agent-ready` issue, labels it `in-progress`, and triggers the implement workflow.
 2. **`autodev-implement`** — Checks out `main`, creates a branch, runs the agent (Claude
-   via `claude-code-action@v1`) to implement the issue, pushes, and opens a PR with
-   auto-merge enabled. The PR triggers CI and `claude-code-review` automatically.
+   via `claude-code-action@v1`) to implement the issue, pushes, and opens a PR.
+   The PR triggers CI and `claude-code-review` automatically.
 3. **`autodev-review-fix`** — Fires when a review requests changes on an `autodev` PR.
    Extracts review feedback, runs the agent to fix issues, and pushes. This re-triggers
    CI + review, creating a feedback loop until the review passes or the iteration limit hits.
+   Human merges manually after all checks pass.
 
 ### Labels
 

--- a/scripts/autodev/open-pr.sh
+++ b/scripts/autodev/open-pr.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 # Usage:
 #   scripts/autodev/open-pr.sh ISSUE_NUMBER BRANCH_NAME
 #
-# Reads issue details, creates PR with structured body, enables auto-merge.
+# Reads issue details, creates PR with structured body.
+# Human merges manually after reviewing.
 
 source "$(dirname "$0")/config.sh"
 
@@ -59,11 +60,5 @@ gh pr close "$PR_NUMBER" --repo "$AUTODEV_REPO"
 gh pr reopen "$PR_NUMBER" --repo "$AUTODEV_REPO"
 
 autodev_info "Closed/reopened PR #$PR_NUMBER to trigger CI"
-
-# ── Enable auto-merge ──────────────────────────────────────────────
-
-gh pr merge "$PR_NUMBER" --repo "$AUTODEV_REPO" --squash --auto
-
-autodev_info "Auto-merge enabled for PR #$PR_NUMBER"
 
 echo "$PR_URL"


### PR DESCRIPTION
## Summary

- **Claude review was silent**: `claude-code-review.yml` had `pull-requests: read` — the action ran but couldn't post reviews. Changed to `write`.
- **Remove auto-merge**: Human merges manually after reviewing autodev PRs. Removed `gh pr merge --auto` from `open-pr.sh`.
- **CLAUDE.md updated**: Reflects human merge step.

## Test Plan

- [ ] CI passes
- [ ] Next autodev PR gets a visible Claude review posted
- [ ] Next autodev PR does NOT auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)