### PR TITLE
fix: use PAT for autodev push/PR ops to trigger downstream workflows

### DIFF
--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Commit and push
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -123,7 +123,7 @@ jobs:
       - name: Create PR
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
         run: |
           bash scripts/autodev/open-pr.sh \
             "${{ inputs.issue_number }}" \

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Commit and push fixes
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,13 @@ Three workflows form a loop:
 | `autodev` | PR was created by the autonomous workflow |
 | `needs-human` | Autodev hit a limit and needs human intervention |
 
+### Secrets required
+
+| Secret | Purpose |
+|--------|---------|
+| `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token for Claude Code agent execution |
+| `AUTODEV_TOKEN` | Fine-grained PAT with Contents, Pull requests, Issues (read/write). Used for push/PR operations so events trigger downstream workflows (GITHUB_TOKEN events don't trigger other workflows). |
+
 ### Circuit breakers
 
 - **Max concurrency**: Only 1 `autodev` PR open at a time (prevents merge conflicts)
@@ -349,6 +356,13 @@ Autodev tracks review-fix iteration count in PR body HTML comments
 (`<!-- autodev-state: {"iteration": N} -->`). This survives PR body edits and is
 invisible to readers. `grep -oP` extracts the value. Always bump the counter after
 each review-fix cycle, and check it before starting a new one.
+
+### L-014: GITHUB_TOKEN cannot trigger downstream workflows
+GitHub's security policy prevents ALL events created by GITHUB_TOKEN from triggering
+other workflows (not just pushes — also PR open/close/reopen). The close/reopen
+workaround doesn't work because those events also come from GITHUB_TOKEN. Use a
+Personal Access Token (PAT) stored as a repo secret (`AUTODEV_TOKEN`) for operations
+that need to trigger CI, code review, or other downstream workflows.
 
 ## Key Files
 

--- a/scripts/autodev/open-pr.sh
+++ b/scripts/autodev/open-pr.sh
@@ -47,18 +47,6 @@ EOF
 )" \
     --label "$AUTODEV_LABEL_AUTODEV")
 
-PR_NUMBER=$(gh pr list --repo "$AUTODEV_REPO" --head "$BRANCH_NAME" --json number --jq '.[0].number')
-
 autodev_info "Created PR: $PR_URL"
-
-# ── Trigger CI ─────────────────────────────────────────────────────
-# Pushes by GITHUB_TOKEN don't trigger downstream workflows (GitHub
-# security policy). Close/reopen the PR to fire the pull_request event
-# which triggers CI and code review.
-
-gh pr close "$PR_NUMBER" --repo "$AUTODEV_REPO"
-gh pr reopen "$PR_NUMBER" --repo "$AUTODEV_REPO"
-
-autodev_info "Closed/reopened PR #$PR_NUMBER to trigger CI"
 
 echo "$PR_URL"


### PR DESCRIPTION
## Summary

Fixes the root cause of autodev PRs not triggering CI or Claude Code Review.

`GITHUB_TOKEN` events cannot trigger other workflows — this is a GitHub security policy that applies to **all** events (push, PR open, close, reopen), not just pushes. The previous close/reopen workaround in `open-pr.sh` was ineffective because those events also originate from `GITHUB_TOKEN`.

**Fix**: Use `AUTODEV_TOKEN` (a fine-grained PAT stored as repo secret) for git push and PR creation steps. Events from PATs trigger downstream workflows normally.

## Changes

- `autodev-implement.yml`: Use `AUTODEV_TOKEN` for commit/push and PR creation steps
- `autodev-review-fix.yml`: Use `AUTODEV_TOKEN` for commit/push step  
- `open-pr.sh`: Remove ineffective close/reopen CI trigger hack
- `CLAUDE.md`: Document `AUTODEV_TOKEN` secret requirement, add L-014 lesson

## Action Required

Before testing, create a fine-grained PAT at GitHub Settings > Developer Settings > Fine-grained PATs:
- **Scope**: `rnwolfe/mine` repository only
- **Permissions**: Contents (R/W), Pull requests (R/W), Issues (R/W)
- **Store as**: repo secret named `AUTODEV_TOKEN`

## Test Plan

- [ ] Create `AUTODEV_TOKEN` secret with fine-grained PAT
- [ ] Close PR #62 (created without CI)
- [ ] Re-trigger `autodev-dispatch` for a test issue
- [ ] Verify CI triggers automatically on the new autodev PR
- [ ] Verify Claude Code Review triggers automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)