### PR TITLE
fix: continue autodev pipeline when agent hits max turns

### DIFF
--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -70,6 +70,8 @@ jobs:
       # To swap providers, replace this step.
       # ============================================================
       - name: Run agent
+        id: agent
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -97,6 +97,8 @@ jobs:
       # To swap providers, replace this step.
       # ============================================================
       - name: Run agent
+        id: agent
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

The `claude-code-action` treats `error_max_turns` as a failure (exit code 1), which causes subsequent steps (commit, push, create PR) to be skipped. This means partial work from the agent is lost even when it produced useful code.

Adds `continue-on-error: true` and `id: agent` to the agent execution step in both `autodev-implement` and `autodev-review-fix` workflows, so partial work still gets committed, pushed, and a PR created.

## Test Plan

- [ ] Trigger autodev-implement on a test issue
- [ ] If agent hits max turns, verify push and PR creation still happen
- [ ] Verify CI and review trigger on the resulting PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)