### PR TITLE
fix: accept both Copilot reviewer identities in review-fix routing

### DIFF
--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -131,7 +131,7 @@ jobs:
             - [ ] Criterion — why it was not met (if any)
             ```
 
-            Write this file as one of your last actions, after completing the implementation.
+            Write this file BEFORE your work is complete — it should be one of your last actions.
           claude_args: "--max-turns 25 --dangerously-skip-permissions"
       # ============================================================
 

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -161,12 +161,18 @@ jobs:
           fi
 
           # For pull_request_review events: check reviewer identity
+          # Note: Copilot reviews appear as either "Copilot" or "copilot-pull-request-reviewer[bot]"
           REVIEWER="${{ github.event.review.user.login }}"
           REVIEW_STATE="${{ github.event.review.state }}"
           echo "reviewer=$REVIEWER" >> "$GITHUB_OUTPUT"
 
+          IS_COPILOT=false
+          if [ "$REVIEWER" = "Copilot" ] || [ "$REVIEWER" = "copilot-pull-request-reviewer[bot]" ]; then
+            IS_COPILOT=true
+          fi
+
           if [ "$PHASE" = "copilot" ]; then
-            if [ "$REVIEWER" != "copilot-pull-request-reviewer[bot]" ]; then
+            if [ "$IS_COPILOT" != "true" ]; then
               echo "Copilot phase but reviewer is $REVIEWER. Skipping."
               echo "action=skip" >> "$GITHUB_OUTPUT"
               exit 0
@@ -195,7 +201,7 @@ jobs:
           fi
 
           if [ "$PHASE" = "claude" ]; then
-            if [ "$REVIEWER" = "copilot-pull-request-reviewer[bot]" ]; then
+            if [ "$IS_COPILOT" = "true" ]; then
               echo "Claude phase but reviewer is Copilot. Skipping."
               echo "action=skip" >> "$GITHUB_OUTPUT"
               exit 0


### PR DESCRIPTION
## Summary

- Fixes the autodev review-fix pipeline silently skipping Copilot reviews because GitHub uses `"Copilot"` as the reviewer login, not `"copilot-pull-request-reviewer[bot]"` as expected
- Adds an `IS_COPILOT` helper variable that accepts both names, used in both copilot-phase and claude-phase routing
- Minor prompt wording fix in `autodev-implement.yml`

## Context

Discovered via [run 22050706339](https://github.com/rnwolfe/mine/actions/runs/22050706339) on PR #69 — Copilot posted a review but the review-fix workflow logged `REVIEWER="Copilot"` and skipped because it only matched `"copilot-pull-request-reviewer[bot]"`.

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Trigger a Copilot review on an autodev PR and confirm review-fix picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)