### PR TITLE
feat: add Maestro Auto Run playbooks for backlog and review loops

### DIFF
--- a/maestro/Backlog-Loop/1_PICK_ISSUE.md
+++ b/maestro/Backlog-Loop/1_PICK_ISSUE.md
@@ -1,0 +1,45 @@
+# Pick Next Backlog Issue
+
+## Context
+
+- **Playbook:** Backlog Loop
+- **Agent:** {{AGENT_NAME}}
+- **Project:** {{AGENT_PATH}}
+- **Auto Run Folder:** {{AUTORUN_FOLDER}}
+- **Loop:** {{LOOP_NUMBER}}
+
+## Objective
+
+Select the next `agent-ready` issue from the GitHub backlog, verify it was labeled by a trusted user, and prepare a working branch. Output the issue details for downstream documents.
+
+## Tasks
+
+- [ ] **Check concurrency**: Run `gh pr list --repo rnwolfe/mine --label autodev --state open --json number --jq 'length'`. If the count is >= 1, write "BLOCKED: concurrency limit reached" to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md` and mark this task complete without proceeding further.
+
+- [ ] **Find candidate issue**: Run `gh issue list --repo rnwolfe/mine --label agent-ready --state open --json number,title,labels --jq '[.[] | select(.labels | map(.name) | index("in-progress") | not)] | sort_by(.number) | first'`. If no issues found, write "BLOCKED: no agent-ready issues" to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md` and mark complete.
+
+- [ ] **Verify trusted labeler**: Use `gh api repos/rnwolfe/mine/issues/ISSUE_NUMBER/timeline --jq '[.[] | select(.event == "labeled" and .label.name == "agent-ready")] | last | .actor.login'` to check who applied the label. Only proceed if the labeler is `rnwolfe`. If untrusted, write "BLOCKED: untrusted labeler" to the issue file and mark complete.
+
+- [ ] **Read issue details**: Run `gh issue view ISSUE_NUMBER --repo rnwolfe/mine --json title,body,labels` and save the full output to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md` in this format:
+
+```markdown
+# Issue #N: Title
+
+## Status
+READY
+
+## Labels
+label1, label2
+
+## Body
+<full issue body>
+```
+
+- [ ] **Mark issue in-progress**: Run `gh issue edit ISSUE_NUMBER --repo rnwolfe/mine --add-label in-progress`.
+
+- [ ] **Create branch**: From the latest `main`, create and checkout a new branch: `git checkout main && git pull origin main && git checkout -b autodev/issue-N-<slugified-title>` where the slug is the title lowercased with non-alphanumeric chars replaced by hyphens, truncated to 50 chars.
+
+## Guidelines
+
+- If the issue file already exists with status `READY`, skip all tasks — the issue was already picked.
+- If ANY blocker is hit (concurrency, no issues, untrusted labeler), write the reason to the issue file so `5_PROGRESS.md` can detect it and exit the loop.

--- a/maestro/Backlog-Loop/2_PLAN.md
+++ b/maestro/Backlog-Loop/2_PLAN.md
@@ -1,0 +1,66 @@
+# Plan Implementation
+
+## Context
+
+- **Playbook:** Backlog Loop
+- **Agent:** {{AGENT_NAME}}
+- **Project:** {{AGENT_PATH}}
+- **Auto Run Folder:** {{AUTORUN_FOLDER}}
+- **Loop:** {{LOOP_NUMBER}}
+
+## Objective
+
+Read the selected issue from `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md`, explore the codebase, and produce a concrete implementation plan. This is the thinking phase — no code changes yet.
+
+## Tasks
+
+- [ ] **Read issue and CLAUDE.md**: Read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md` for the issue details. If the status is not `READY`, mark this task complete without proceeding. Then read `CLAUDE.md` for project conventions, architecture patterns, and file organization rules.
+
+- [ ] **Explore relevant code**: Based on the issue requirements, explore the codebase to understand:
+  - Which existing packages/files are relevant
+  - What patterns are already used (command structure, domain packages, store layer, UI helpers)
+  - Where new code should live following existing conventions
+  - What existing tests look like for similar functionality
+
+- [ ] **Design implementation approach**: Write a plan to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md` with:
+
+```markdown
+# Implementation Plan: Issue #N — Title
+
+## Approach
+<2-3 sentences describing the overall approach>
+
+## Files to Create
+- `path/to/new/file.go` — purpose
+- `path/to/new/file_test.go` — what it tests
+
+## Files to Modify
+- `path/to/existing.go` — what changes and why
+
+## Architecture Decisions
+- <Any design choices: data model, package boundaries, API surface>
+
+## CLI Surface
+- `mine <command> [flags]` — description of new commands/subcommands
+- New flags on existing commands (if any)
+
+## Test Strategy
+- Unit tests for: <list>
+- Edge cases: <list>
+- Integration points: <list>
+
+## Risks & Considerations
+- <Anything tricky, any existing code that might conflict>
+
+## Acceptance Criteria Mapping
+- [ ] Criterion from issue → planned implementation detail
+- [ ] ...
+```
+
+## Guidelines
+
+- Follow the project's domain separation pattern: thin `cmd/` orchestration, domain logic in `internal/<package>/`
+- Keep files under 500 lines
+- Use the store pattern (`store.DB` wrapper) for any new data persistence
+- All output through `internal/ui` helpers — never raw `fmt.Println`
+- Do NOT plan changes to CLAUDE.md, `.github/workflows/`, or `scripts/autodev/`

--- a/maestro/Backlog-Loop/3_IMPLEMENT.md
+++ b/maestro/Backlog-Loop/3_IMPLEMENT.md
@@ -1,0 +1,44 @@
+# Implement Feature
+
+## Context
+
+- **Playbook:** Backlog Loop
+- **Agent:** {{AGENT_NAME}}
+- **Project:** {{AGENT_PATH}}
+- **Auto Run Folder:** {{AUTORUN_FOLDER}}
+- **Loop:** {{LOOP_NUMBER}}
+
+## Objective
+
+Execute the implementation plan from `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md`. Write code, write tests, and verify everything builds and passes.
+
+## Tasks
+
+- [ ] **Read the plan**: Read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md`. If the file doesn't exist, mark this task complete without proceeding — there's nothing to implement.
+
+- [ ] **Implement the feature**: Following the plan, create and modify files as specified. Adhere to these rules:
+  - Read CLAUDE.md for project conventions
+  - Follow existing code patterns and style
+  - Do NOT modify CLAUDE.md, any files in `.github/workflows/`, or `scripts/autodev/`
+  - Keep files under 500 lines
+  - Use `internal/ui` helpers for all output
+  - Use the store pattern for data persistence
+
+- [ ] **Write tests**: Create `_test.go` files alongside the code. Cover:
+  - Happy path for each new function
+  - Error cases and edge cases
+  - Any acceptance criteria that can be verified programmatically
+
+- [ ] **Run tests**: Execute `make test` and verify all tests pass (including existing tests). If tests fail, fix the issues before proceeding.
+
+- [ ] **Run build**: Execute `make build` and verify the binary builds successfully. If the build fails, fix the issues.
+
+- [ ] **Verify protected files**: Run `git diff --name-only` and confirm no changes to CLAUDE.md, `.github/workflows/`, or `scripts/autodev/`. If any protected files were modified, revert them with `git checkout -- <file>`.
+
+## Guidelines
+
+- Implement exactly what the plan specifies — don't add unplanned features
+- If you discover the plan has a flaw, make a reasonable adjustment and note it
+- Run `make test` frequently during implementation, not just at the end
+- Prefer editing existing files over creating new ones where it makes sense
+- Don't add unnecessary abstractions — keep it simple

--- a/maestro/Backlog-Loop/4_OPEN_PR.md
+++ b/maestro/Backlog-Loop/4_OPEN_PR.md
@@ -1,0 +1,92 @@
+# Open Pull Request
+
+## Context
+
+- **Playbook:** Backlog Loop
+- **Agent:** {{AGENT_NAME}}
+- **Project:** {{AGENT_PATH}}
+- **Auto Run Folder:** {{AUTORUN_FOLDER}}
+- **Loop:** {{LOOP_NUMBER}}
+
+## Objective
+
+Commit all changes, push the branch, and create a detailed PR. The PR description should be comprehensive enough for a human reviewer to understand exactly what was built and why.
+
+## Tasks
+
+- [ ] **Check for changes**: Run `git diff --stat` and `git diff --cached --stat`. If there are no changes (both empty), write "SKIPPED: no changes to commit" to `{{AUTORUN_FOLDER}}/BACKLOG_LOG_{{DATE}}.md` and mark complete without proceeding.
+
+- [ ] **Read issue details**: Read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md` to get the issue number and title. Read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md` for the implementation plan.
+
+- [ ] **Commit changes**: Stage and commit all changes:
+  ```
+  git add -A
+  git commit -m "feat: implement #ISSUE_NUMBER"
+  ```
+  Do NOT commit files that contain secrets or credentials.
+
+- [ ] **Push branch**: Push the branch to origin:
+  ```
+  git push -u origin BRANCH_NAME
+  ```
+
+- [ ] **Create PR with detailed description**: Create the PR using `gh pr create` with a comprehensive body. The PR must include:
+
+  **Title:** The issue title (from the issue file)
+
+  **Body structure:**
+  ```markdown
+  ## Summary
+
+  <2-4 sentence overview of what was implemented and why.
+   Reference the design approach from the plan.>
+
+  Closes #ISSUE_NUMBER
+
+  ## Changes
+
+  <Bulleted list of all changes, organized by area:>
+  - **New files**: each new file and its purpose
+  - **Modified files**: each modified file and what changed
+  - **Architecture**: design decisions and patterns used
+
+  ## CLI Surface
+
+  <New commands, subcommands, and flags added.
+   Include usage examples.>
+  - `mine <command>` — description
+  - Flags: `--flag` — description
+
+  ## Test Coverage
+
+  <What tests were added:>
+  - Unit tests for ...
+  - Edge cases covered: ...
+
+  ## Acceptance Criteria
+
+  <Verified against issue #N:>
+  - [x] Criterion — how it was met
+  - [ ] Criterion — why it wasn't met (if any)
+  ```
+
+  Add the `autodev` label: `--label autodev`
+
+  Append the autodev state tracker at the end of the body:
+  `<!-- autodev-state: {"phase": "copilot", "copilot_iterations": 0} -->`
+
+- [ ] **Log the PR**: Append to `{{AUTORUN_FOLDER}}/BACKLOG_LOG_{{DATE}}.md`:
+  ```markdown
+  ## Loop {{LOOP_NUMBER}} — Issue #N: Title
+  - **Branch:** branch-name
+  - **PR:** PR_URL
+  - **Status:** PR opened
+  - **Files changed:** N
+  ```
+
+## Guidelines
+
+- The PR description is critical — it's the first thing reviewers see. Be thorough.
+- Use conventional commit format for the commit message (`feat:`, `fix:`, etc.)
+- Don't force push or rewrite history
+- Verify the PR was created successfully before marking complete

--- a/maestro/Backlog-Loop/5_PROGRESS.md
+++ b/maestro/Backlog-Loop/5_PROGRESS.md
@@ -1,0 +1,54 @@
+# Progress Check — Loop Control
+
+## Context
+
+- **Playbook:** Backlog Loop
+- **Agent:** {{AGENT_NAME}}
+- **Project:** {{AGENT_PATH}}
+- **Auto Run Folder:** {{AUTORUN_FOLDER}}
+- **Loop:** {{LOOP_NUMBER}}
+
+## Objective
+
+Determine whether to continue the loop or exit. This document controls the pipeline:
+- If more `agent-ready` issues exist and no blockers, reset documents 1-4 to trigger another loop.
+- If blocked or backlog is empty, leave documents 1-4 completed so the pipeline exits.
+
+## Tasks
+
+- [ ] **Check for blockers**: Read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md`. If the status contains "BLOCKED" (concurrency limit, no issues, untrusted labeler), do NOT reset any documents — the pipeline should exit. Append the blocker reason to `{{AUTORUN_FOLDER}}/BACKLOG_LOG_{{DATE}}.md` and mark this task complete.
+
+- [ ] **Check backlog**: Run `gh issue list --repo rnwolfe/mine --label agent-ready --state open --json number,labels --jq '[.[] | select(.labels | map(.name) | index("in-progress") | not)] | length'`. If the count is 0, do NOT reset documents — the backlog is empty. Append "Backlog empty — pipeline exiting" to the log and mark complete.
+
+- [ ] **Check concurrency**: Run `gh pr list --repo rnwolfe/mine --label autodev --state open --json number --jq 'length'`. If >= 1, do NOT reset — wait for the current PR to be merged before processing more. Append "Concurrency limit — waiting for PR merge" to the log and mark complete.
+
+- [ ] **Return to main**: Run `git checkout main && git pull origin main` to prepare for the next iteration.
+
+- [ ] **Reset for next loop**: If none of the above blockers apply, reset all tasks in documents 1 through 4 by unchecking all checkboxes in:
+  - `{{AUTORUN_FOLDER}}/1_PICK_ISSUE.md`
+  - `{{AUTORUN_FOLDER}}/2_PLAN.md`
+  - `{{AUTORUN_FOLDER}}/3_IMPLEMENT.md`
+  - `{{AUTORUN_FOLDER}}/4_OPEN_PR.md`
+
+  Change every `- [x]` back to `- [ ]` in those files. This signals Auto Run to process them again in the next loop iteration.
+
+  Append to `{{AUTORUN_FOLDER}}/BACKLOG_LOG_{{DATE}}.md`:
+  ```markdown
+  ---
+  Loop {{LOOP_NUMBER}} complete. More issues available — continuing to next loop.
+  ```
+
+## Exit Conditions (do NOT reset)
+
+The pipeline exits when ANY of these are true:
+1. Issue file contains "BLOCKED"
+2. No `agent-ready` issues remain (backlog empty)
+3. An autodev PR is already open (concurrency limit)
+
+When exiting, leave documents 1-4 with their tasks checked. Auto Run will see no unchecked tasks and stop.
+
+## Guidelines
+
+- This document has **Reset on Completion** enabled in the playbook config
+- Documents 1-4 do NOT have Reset on Completion — they only reset when this document explicitly unchecks their tasks
+- Always append to the log, never overwrite it

--- a/maestro/Backlog-Loop/README.md
+++ b/maestro/Backlog-Loop/README.md
@@ -1,0 +1,64 @@
+# Backlog Loop Playbook
+
+A looping Auto Run playbook that picks issues from the GitHub backlog, implements them, opens PRs, and repeats until the backlog is empty or the concurrency limit is reached.
+
+## Requirements
+
+- **Agent:** Claude Code
+- **Project:** `mine` CLI (Go)
+- **Tools:** `gh` CLI authenticated with repo access
+
+## Overview
+
+This playbook automates the same workflow as the `autodev-dispatch` + `autodev-implement` GitHub Actions pipeline, but driven locally via Maestro for faster iteration and developer oversight.
+
+Each loop:
+1. **Picks** the next `agent-ready` issue from the backlog
+2. **Plans** the implementation approach
+3. **Implements** the feature with tests
+4. **Opens a PR** with a detailed description
+5. **Checks progress** and loops if more issues are available
+
+## Document Chain
+
+| Document | Purpose | Reset on Completion? |
+|----------|---------|---------------------|
+| `1_PICK_ISSUE.md` | Select next backlog issue, verify trust, create branch | No |
+| `2_PLAN.md` | Read issue, explore codebase, design implementation approach | No |
+| `3_IMPLEMENT.md` | Implement the feature, write tests, verify build | No |
+| `4_OPEN_PR.md` | Commit, push, create PR with detailed description | No |
+| `5_PROGRESS.md` | Check for more issues, reset 1-4 if available, exit if done | **Yes** |
+
+## Recommended Setup
+
+```
+Loop Mode: ON
+Documents:
+  1_PICK_ISSUE.md   [Reset: OFF]  ← Gets reset by 5_PROGRESS
+  2_PLAN.md         [Reset: OFF]  ← Gets reset by 5_PROGRESS
+  3_IMPLEMENT.md    [Reset: OFF]  ← Gets reset by 5_PROGRESS
+  4_OPEN_PR.md      [Reset: OFF]  ← Gets reset by 5_PROGRESS
+  5_PROGRESS.md     [Reset: ON]   ← Controls loop: resets 1-4 if work remains
+```
+
+## Generated Files
+
+Each loop creates:
+- `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md` — Selected issue details
+- `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md` — Implementation plan
+- `{{AUTORUN_FOLDER}}/BACKLOG_LOG_{{DATE}}.md` — Cumulative log of all issues processed
+
+## Safety
+
+- Only processes issues labeled by trusted users (checked via timeline API)
+- Protected files (CLAUDE.md, workflows, autodev scripts) are never modified
+- Max 1 open autodev PR at a time (concurrency guard)
+- Each implementation runs `make test` and `make build` before committing
+
+## Template Variables
+
+- `{{AGENT_NAME}}` — Maestro agent name
+- `{{AGENT_PATH}}` — Project root path
+- `{{AUTORUN_FOLDER}}` — Path to this playbook folder
+- `{{LOOP_NUMBER}}` — Current loop iteration
+- `{{DATE}}` — Today's date (YYYY-MM-DD)

--- a/maestro/Review-Fix/1_EXTRACT_FEEDBACK.md
+++ b/maestro/Review-Fix/1_EXTRACT_FEEDBACK.md
@@ -1,0 +1,44 @@
+# Extract Review Feedback
+
+## Context
+
+- **Playbook:** Review Fix
+- **Agent:** {{AGENT_NAME}}
+- **Project:** {{AGENT_PATH}}
+- **Auto Run Folder:** {{AUTORUN_FOLDER}}
+- **Loop:** {{LOOP_NUMBER}}
+- **PR Number:** PR_NUMBER
+
+## Objective
+
+Extract all actionable review feedback from the PR and write it to a structured file for the fix step.
+
+## Tasks
+
+- [ ] **Fetch top-level reviews**: Run `gh api repos/rnwolfe/mine/pulls/PR_NUMBER/reviews --jq '[.[] | select((.state == "CHANGES_REQUESTED" or .state == "COMMENTED") and (.body != null and .body != "") and (.user.login != "github-actions[bot]"))] | sort_by(.submitted_at) | reverse | .[0:5]'`. Extract reviewer, state, body, and review ID for each.
+
+- [ ] **Fetch inline comments**: Run `gh api repos/rnwolfe/mine/pulls/PR_NUMBER/comments --jq '[.[] | select(.user.login != "github-actions[bot]")] | sort_by(.created_at) | reverse | .[0:20]'`. Extract author, file path, line number, body, and comment ID for each.
+
+- [ ] **Write feedback file**: Save structured feedback to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_FEEDBACK.md`:
+
+```markdown
+# Review Feedback — Loop {{LOOP_NUMBER}}
+
+## Review Comments
+
+### reviewer (STATE) [review_id: ID]
+<body>
+
+## Inline Comments
+
+### path/to/file.go:42 (author) [comment_id: ID]
+<body>
+```
+
+If no feedback is found (no reviews and no inline comments), write "NO_FEEDBACK" as the only content. This signals the loop to exit.
+
+## Guidelines
+
+- Include ALL comments, not just the latest — the agent should see full context
+- Always include the `comment_id` and `review_id` tags — they're needed for replies
+- Filter out `github-actions[bot]` comments (those are our own bot)

--- a/maestro/Review-Fix/2_FIX_AND_REPLY.md
+++ b/maestro/Review-Fix/2_FIX_AND_REPLY.md
@@ -1,0 +1,42 @@
+# Fix Issues and Reply to Comments
+
+## Context
+
+- **Playbook:** Review Fix
+- **Agent:** {{AGENT_NAME}}
+- **Project:** {{AGENT_PATH}}
+- **Auto Run Folder:** {{AUTORUN_FOLDER}}
+- **Loop:** {{LOOP_NUMBER}}
+- **PR Number:** PR_NUMBER
+
+## Objective
+
+Read the review feedback, fix each issue in the code, and reply directly to each inline comment on GitHub explaining what was changed.
+
+## Tasks
+
+- [ ] **Read feedback**: Read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_FEEDBACK.md`. If the content is "NO_FEEDBACK", mark this task complete without proceeding.
+
+- [ ] **Read project conventions**: Read `CLAUDE.md` for project patterns, architecture rules, and coding standards.
+
+- [ ] **Address each comment**: For each piece of review feedback:
+  1. Understand what the reviewer is asking for
+  2. Make the code change (or determine why no change is needed)
+  3. If you made a change, verify it doesn't break tests (`make test`)
+  4. Reply directly to inline comments using:
+     ```
+     gh api "repos/rnwolfe/mine/pulls/PR_NUMBER/comments/COMMENT_ID/replies" -f body="<explanation of what you changed>"
+     ```
+  5. If you chose not to change something, reply explaining why
+
+- [ ] **Verify build**: Run `make test && make build` to confirm everything passes.
+
+- [ ] **Check protected files**: Run `git diff --name-only` and verify no changes to CLAUDE.md, `.github/workflows/`, or `scripts/autodev/`. Revert any protected file changes with `git checkout -- <file>`.
+
+## Guidelines
+
+- Do NOT modify CLAUDE.md, any files in `.github/workflows/`, or `scripts/autodev/`
+- Address ALL comments — don't skip any
+- Keep replies concise but informative
+- If a comment can't be fully resolved, explain what was done and what remains
+- Run tests after fixing each group of related changes, not just at the end

--- a/maestro/Review-Fix/3_PUSH.md
+++ b/maestro/Review-Fix/3_PUSH.md
@@ -1,0 +1,45 @@
+# Push Changes and Check Progress
+
+## Context
+
+- **Playbook:** Review Fix
+- **Agent:** {{AGENT_NAME}}
+- **Project:** {{AGENT_PATH}}
+- **Auto Run Folder:** {{AUTORUN_FOLDER}}
+- **Loop:** {{LOOP_NUMBER}}
+- **PR Number:** PR_NUMBER
+
+## Objective
+
+Commit and push the fixes, then check if there's likely to be more feedback. If the feedback file was empty (NO_FEEDBACK), exit the loop.
+
+## Tasks
+
+- [ ] **Check for exit condition**: Read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_FEEDBACK.md`. If the content is "NO_FEEDBACK", do NOT reset documents 1-2 — the loop should exit. Mark this task complete.
+
+- [ ] **Check for changes**: Run `git diff --stat`. If there are no changes, do NOT reset — nothing to push. Mark complete.
+
+- [ ] **Commit and push**: Stage and commit all changes, then push:
+  ```
+  git add -A
+  git commit -m "fix: address review feedback (iteration {{LOOP_NUMBER}})"
+  git push
+  ```
+
+- [ ] **Reset for next loop**: Reset all tasks in documents 1 and 2 by unchecking all checkboxes in:
+  - `{{AUTORUN_FOLDER}}/1_EXTRACT_FEEDBACK.md`
+  - `{{AUTORUN_FOLDER}}/2_FIX_AND_REPLY.md`
+
+  Change every `- [x]` back to `- [ ]` in those files. This allows the next loop to extract fresh feedback after the reviewer re-reviews.
+
+## Exit Conditions (do NOT reset)
+
+- Feedback file contains "NO_FEEDBACK" — no more review comments to address
+- No code changes were made — nothing to push
+- Loop {{LOOP_NUMBER}} >= 3 — max iterations reached, needs human attention
+
+## Guidelines
+
+- This document has **Reset on Completion** enabled
+- Documents 1-2 only reset when this document explicitly unchecks their tasks
+- After pushing, the reviewer (Copilot or human) will re-review, and the next loop iteration will pick up any new feedback

--- a/maestro/Review-Fix/README.md
+++ b/maestro/Review-Fix/README.md
@@ -1,0 +1,42 @@
+# Review Fix Playbook
+
+A looping Auto Run playbook that addresses PR review feedback, replies to comments, and iterates until reviews are clean.
+
+## Requirements
+
+- **Agent:** Claude Code
+- **Project:** `mine` CLI (Go)
+- **Tools:** `gh` CLI authenticated with repo access
+
+## Overview
+
+This replaces the `autodev-review-fix` GitHub Actions workflow for local use. It processes review feedback on an autodev PR, fixes issues, replies to comments, and loops until no actionable feedback remains.
+
+Each loop:
+1. **Extracts** review feedback from the PR
+2. **Fixes** the issues and replies to each comment
+3. **Pushes** the changes
+4. **Waits** for re-review and checks if more feedback exists
+
+## Setup
+
+Before running, set the PR number in `1_EXTRACT_FEEDBACK.md` by replacing `PR_NUMBER` with the actual number.
+
+## Document Chain
+
+| Document | Purpose | Reset on Completion? |
+|----------|---------|---------------------|
+| `1_EXTRACT_FEEDBACK.md` | Parse review comments from the PR | No |
+| `2_FIX_AND_REPLY.md` | Address each comment, reply on GitHub | No |
+| `3_PUSH.md` | Commit, push, check for more feedback | **Yes** |
+
+## Recommended Setup
+
+```
+Loop Mode: ON
+Max Loops: 3
+Documents:
+  1_EXTRACT_FEEDBACK.md  [Reset: OFF]  ← Gets reset by 3_PUSH
+  2_FIX_AND_REPLY.md     [Reset: OFF]  ← Gets reset by 3_PUSH
+  3_PUSH.md              [Reset: ON]   ← Controls loop
+```


### PR DESCRIPTION
## Summary

- Adds two Maestro Auto Run playbooks for agent-driven development loops
- **Backlog-Loop** (5 docs): picks `agent-ready` issues, plans, implements, opens PRs, loops until backlog is empty or blocked
- **Review-Fix** (3 docs): extracts PR review feedback, fixes with direct comment replies, pushes, loops until clean

## Details

Both playbooks use Maestro template variables (`{{AGENT_NAME}}`, `{{LOOP_NUMBER}}`, etc.) and checkbox-based task tracking. Loop control is managed by a final progress/push document that resets earlier documents' checkboxes for the next iteration.

These are alternatives to the GitHub Actions autodev workflows for local agent-driven development using [Maestro](https://docs.runmaestro.ai/autorun-playbooks).

## Test plan

- [ ] Load Backlog-Loop in Maestro Auto Run and verify document chain works
- [ ] Load Review-Fix in Maestro Auto Run with a real PR number and verify loop behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)