### PR TITLE
fix: increase agent max turns and timeouts for autonomous dev

### DIFF
--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   implement:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -132,7 +132,7 @@ jobs:
             ```
 
             Write this file as one of your last actions, after completing the implementation.
-          claude_args: "--max-turns 25 --dangerously-skip-permissions"
+          claude_args: "--max-turns 100 --dangerously-skip-permissions"
       # ============================================================
 
       - name: Revert protected file changes

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -27,7 +27,7 @@ jobs:
     # Skip events triggered by bots that aren't relevant reviewers
     if: github.actor != 'vercel[bot]'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       # ── Determine action ──────────────────────────────────────────
       - name: Determine action
@@ -291,7 +291,7 @@ jobs:
             ## Review Feedback to Address
 
             ${{ env.REVIEW_FEEDBACK }}
-          claude_args: "--max-turns 15 --dangerously-skip-permissions"
+          claude_args: "--max-turns 50 --dangerously-skip-permissions"
       # ============================================================
 
       - name: Handle agent failure (copilot fix)
@@ -440,7 +440,7 @@ jobs:
             ## Review Feedback to Address
 
             ${{ env.REVIEW_FEEDBACK }}
-          claude_args: "--max-turns 15 --dangerously-skip-permissions"
+          claude_args: "--max-turns 50 --dangerously-skip-permissions"
       # ============================================================
 
       - name: Handle agent failure (claude fix)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,10 +195,11 @@ Phases: `copilot` → `claude` → `done`
 - **Max concurrency**: Only 1 `autodev` PR open at a time (prevents merge conflicts)
 - **Copilot iterations**: Up to 3 fix cycles on Copilot feedback before transitioning to Claude
 - **Claude fix**: 1 final fix cycle after Claude review
-- **Timeouts**: 30 min for implementation, 20 min for review fixes
+- **Timeouts**: 60 min for implementation, 45 min for review fixes
+- **Max turns**: 100 for implementation, 50 for review fixes (high to allow complex work, prevents infinite loops)
 - **Protected files**: Agent cannot modify CLAUDE.md, workflows, or autodev scripts
 - **Trusted users**: Only users in `AUTODEV_TRUSTED_USERS` (config.sh) can trigger autodev via `agent-ready` label
-- **Scheduled review poll**: Every 15 min fallback catches reviews from bot actors gated by GitHub's contributor approval
+- **Scheduled review poll**: Every 4 hours fallback catches reviews from bot actors gated by GitHub's contributor approval
 
 ### Model-agnostic design
 


### PR DESCRIPTION
## Summary

- Increases max turns from 25→100 (implement) and 15→50 (review fix) to allow complex autonomous work without premature termination
- Increases job timeouts from 30→60 min (implement) and 20→45 min (review fix) to match
- Fixes stale "every 15 min" reference in CLAUDE.md (was changed to every 4 hours)

The previous low limits caused agents to hit max turns on non-trivial issues (e.g., PR #69 hit the limit during review fix). The new limits are high enough for real work but still serve as a circuit breaker against infinite loops.

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Next autodev run uses new limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)