### PR TITLE
fix: add path filter to CI so non-code PRs aren't blocked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+      - ".github/workflows/ci.yml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Adds `paths` filter to CI's `pull_request` trigger so it only runs when Go code, go.mod/sum, Makefile, or ci.yml change
- PRs that only touch docs, workflow YAML, or other non-code files will have the required `test` check auto-passed by GitHub instead of pending forever

## Context

PRs #73/74/76 were blocked because CI never triggered (only workflow YAML + CLAUDE.md changed), but the `test` required status check stayed pending indefinitely. Without explicit `paths` filters, GitHub can't distinguish "CI not needed" from "CI broken", so it never auto-passes the check.

## Test plan

- [ ] This PR itself should demonstrate the fix — CI should either run (because `ci.yml` is in the paths list) or auto-pass
- [ ] A future docs-only PR should not be blocked by the `test` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)