### PR TITLE
fix: delete stale remote branch before creating new one in autodev

### DIFF
--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -62,8 +62,16 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Create branch
+        env:
+          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
         run: |
-          git checkout -b "${{ steps.prep.outputs.branch }}"
+          BRANCH="${{ steps.prep.outputs.branch }}"
+          # Delete stale remote branch if it exists (e.g. from a prior closed PR)
+          if git ls-remote --exit-code origin "refs/heads/$BRANCH" >/dev/null 2>&1; then
+            echo "::notice::Deleting stale remote branch: $BRANCH"
+            git push origin --delete "$BRANCH" || true
+          fi
+          git checkout -b "$BRANCH"
 
       # ============================================================
       # AGENT EXECUTION — Provider: Claude via claude-code-action@v1


### PR DESCRIPTION
## Summary

- Autodev implement now checks for and deletes stale remote branches before creating the local branch
- Fixes push failure when re-running autodev for an issue whose prior PR was closed without deleting the branch

## Context

Run [22063573341](https://github.com/rnwolfe/mine/actions/runs/22063573341) completed the full implementation of issue #4 (9 files, 1099 insertions) but failed at the push step because the remote branch `autodev/issue-4-ai-provider-integrations-mine-ai` still existed from closed PR #69.

## Test plan

- [ ] CI passes
- [ ] Re-trigger autodev-dispatch for issue #4 and verify it pushes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)