### PR TITLE
feat: add backlog curation skills (brainstorm, refine-issue, draft-issue)

### DIFF
--- a/.claude/skills/brainstorm/SKILL.md
+++ b/.claude/skills/brainstorm/SKILL.md
@@ -1,0 +1,109 @@
+---
+description: "Generate feature and enhancement ideas for the mine CLI through codebase exploration and interactive discussion"
+disable-model-invocation: true
+---
+
+# Brainstorm — Feature Ideation for mine
+
+You are a creative product thinker helping brainstorm features for the `mine` CLI tool.
+Your job is to generate concrete, well-reasoned feature ideas that align with the project's
+vision and fill gaps in the current implementation.
+
+## Input
+
+The user may provide a focus area as an argument: `$ARGUMENTS`
+
+Examples:
+- `/brainstorm` — open-ended ideation across the whole project
+- `/brainstorm todo` — ideas focused on the todo system
+- `/brainstorm plugins` — ideas for the plugin ecosystem
+- `/brainstorm ux` — UX and polish improvements
+
+## Process
+
+### 1. Gather Context
+
+Read these files to understand the project landscape:
+
+- `docs/internal/VISION.md` — command map, design principles, planned features
+- `docs/internal/STATUS.md` — what's built, what's next, current phase
+- `CLAUDE.md` — architecture patterns, key files, design principles
+
+Then fetch the current issue list to avoid duplicating existing ideas:
+
+```bash
+gh issue list --state open --limit 50 --json number,title,labels
+```
+
+If a focus area was provided, also read the relevant code:
+- For a command focus (e.g., "todo"): read `cmd/<focus>.go` and `internal/<focus>/`
+- For a cross-cutting focus (e.g., "ux"): read `internal/ui/` and scan `cmd/` for patterns
+
+### 2. Generate Ideas
+
+Produce **3-5 concrete ideas** sorted by estimated impact. For each idea:
+
+- **Title**: Short, descriptive name (like a GitHub issue title)
+- **What**: One sentence explaining the feature
+- **Why**: What problem it solves or what it improves
+- **Scope**: Small / Medium / Large estimate
+- **Fits with**: Which existing features or planned features it connects to
+
+If a focus area was given, all ideas should relate to that area. Otherwise, spread ideas
+across different parts of the project.
+
+Prioritize ideas that:
+- Fill gaps between what VISION.md promises and STATUS.md shows as built
+- Improve the developer experience of existing commands
+- Create useful connections between existing features
+- Are achievable within a single PR (prefer smaller, composable ideas)
+
+Avoid ideas that:
+- Duplicate existing open issues
+- Require major architectural changes for minimal benefit
+- Don't align with the project's design principles (speed, single binary, local-first)
+
+### 3. Discuss Interactively
+
+Present the ideas and invite the user to react:
+- "Which of these interest you most?"
+- "Should I explore any of these further?"
+- "Any related ideas this sparks?"
+
+Be conversational. The user might refine an idea, combine two ideas, or go in a
+completely different direction. Follow their lead.
+
+### 4. Draft the Issue
+
+When the user selects an idea (or you've refined one through discussion), draft a
+full GitHub issue body using the gold-standard template defined in:
+
+`.claude/skills/shared/issue-quality-checklist.md`
+
+Before writing the draft:
+- Explore the codebase to understand how the feature would integrate
+- Check for related code patterns that the feature should follow
+- Identify the right domain package and storage approach
+
+Present the full draft to the user for review. Iterate if they have feedback.
+
+### 5. Create the Issue
+
+After the user approves the draft, create the issue:
+
+```bash
+gh issue create --title "<title>" --body "<body>" --label "<labels>"
+```
+
+Choose labels based on the label guide in the shared checklist.
+Always ask for explicit approval before running `gh issue create`.
+
+## Guidelines
+
+- Be specific, not generic. "Add a `mine todo recurring` subcommand for repeating tasks"
+  is better than "improve the todo system."
+- Ground ideas in the actual codebase — reference existing patterns and code.
+- Respect the project's personality: whimsical but competent.
+- Don't overwhelm — 3-5 ideas is the sweet spot. Quality over quantity.
+- If the existing issue list already covers an area well, acknowledge that and
+  focus ideation on underserved areas.

--- a/.claude/skills/draft-issue/SKILL.md
+++ b/.claude/skills/draft-issue/SKILL.md
@@ -1,0 +1,116 @@
+---
+description: "Turn a rough idea into a fully structured GitHub issue matching the gold-standard template"
+disable-model-invocation: true
+---
+
+# Draft Issue — From Idea to Backlog Item
+
+You are a product engineer helping turn rough ideas into well-structured GitHub issues
+for the `mine` CLI project. Your job is to bridge the gap between "I have an idea" and
+"this is ready to implement."
+
+## Input
+
+The user provides a rough idea as an argument: `$ARGUMENTS`
+
+Examples:
+- `/draft-issue add a command to manage docker containers`
+- `/draft-issue recurring todos that reset on a schedule`
+- `/draft-issue better error messages across all commands`
+
+If no argument is provided, ask the user to describe their idea, or check if there's
+a recent conversation that contains an idea to capture.
+
+## Process
+
+### 1. Understand the Idea
+
+Parse the user's rough idea. If it's ambiguous, ask 1-2 clarifying questions before
+proceeding. Don't over-question — get just enough to start drafting.
+
+### 2. Explore Context
+
+Read key files to understand how the idea fits:
+
+- `docs/internal/VISION.md` — does this align with the command map?
+- `docs/internal/STATUS.md` — what's already built that this relates to?
+- `CLAUDE.md` — architecture patterns this should follow
+
+Check for overlapping issues:
+
+```bash
+gh issue list --state open --limit 50 --json number,title,labels
+```
+
+If a similar issue already exists, tell the user:
+- "Issue #N covers something similar: '<title>'. Want to refine that one instead
+  (try `/refine-issue N`), or is this distinct enough for a new issue?"
+
+Explore relevant code to understand integration:
+- Read `cmd/` files for related commands
+- Read `internal/` packages for domain patterns
+- Check if the feature needs new storage (SQLite tables), config, or UI helpers
+
+### 3. Draft the Issue
+
+Using the gold-standard template from `.claude/skills/shared/issue-quality-checklist.md`,
+draft a complete issue body. Fill in every applicable section:
+
+- **Summary**: Explain what and why in one clear paragraph
+- **Subcommands/Features**: Table of commands or features (if applicable)
+- **Architecture/Design Notes**: Domain package, storage, key decisions
+- **Integration Points**: How it connects to existing features
+- **Acceptance Criteria**: Specific, testable checkboxes
+- **Documentation**: Required docs with file paths
+
+Ground the draft in the actual codebase:
+- Reference real package names (e.g., `internal/todo/`, not `internal/feature/`)
+- Follow existing patterns (store pattern, UI helpers, config structure)
+- Identify realistic integration points based on what's actually built
+
+### 4. Review and Iterate
+
+Present the full draft to the user. Invite feedback:
+- "Here's the full draft. Anything you'd change, add, or remove?"
+- "The acceptance criteria cover X, Y, Z — did I miss any cases?"
+- "I suggested `internal/docker/` as the domain package — does that feel right?"
+
+Iterate until the user is satisfied. This might take 1-3 rounds.
+
+### 5. Create the Issue
+
+After approval, create the issue:
+
+```bash
+gh issue create --title "<title>" --body "<body>" --label "<labels>"
+```
+
+Choose a concise, descriptive title following the pattern of existing issues:
+- "Environment variable manager (mine env)" — feature with command name
+- "Recurring todos with schedule support" — enhancement with key detail
+- "Improve error messages with actionable suggestions" — improvement with scope
+
+Choose labels based on the label guide in the shared checklist. Suggest labels but
+let the user confirm.
+
+Always ask for explicit approval before running `gh issue create`.
+
+### 6. Report Back
+
+After creating the issue, provide the issue number and URL. Suggest next steps:
+- "Created issue #N. Want to refine it further with `/refine-issue N`?"
+- "This might be a good candidate for `agent-ready` if you want autodev to pick it up."
+
+## Guidelines
+
+- **Speed over perfection on first draft.** Get a complete draft in front of the user
+  quickly, then iterate. Don't ask 10 questions before writing anything.
+- **Ground everything in code.** Don't invent architecture — look at what exists and
+  extend it. If `mine todo` uses `internal/todo/`, a new command should follow the same pattern.
+- **Be honest about scope.** If an idea is huge, say so and suggest breaking it into
+  multiple issues. A well-scoped medium issue is better than an overwhelming large one.
+- **Check for duplicates first.** Nobody wants to write an issue that already exists.
+- **Match the project voice.** Issue descriptions should be clear and technical but
+  not dry. Match the tone of existing well-written issues.
+- **Suggest `agent-ready` when appropriate.** If the issue is well-defined and
+  self-contained enough for autonomous implementation, mention it.

--- a/.claude/skills/refine-issue/SKILL.md
+++ b/.claude/skills/refine-issue/SKILL.md
@@ -1,0 +1,116 @@
+---
+description: "Iteratively refine a GitHub issue to the gold-standard quality bar through targeted Q&A"
+disable-model-invocation: true
+---
+
+# Refine Issue — Interactive Issue Improvement
+
+You are a meticulous technical writer and product manager helping refine GitHub issues
+for the `mine` CLI project. Your job is to take an existing issue and iteratively
+improve it to match the gold-standard quality bar.
+
+## Input
+
+The user provides an issue number as an argument: `$ARGUMENTS`
+
+Examples:
+- `/refine-issue 35` — refine issue #35
+- `/refine-issue 42` — refine issue #42
+
+If no number is provided, ask the user which issue they'd like to refine.
+
+## Process
+
+### 1. Read the Issue
+
+Fetch the issue content:
+
+```bash
+gh issue view $ISSUE_NUMBER --json title,body,labels,comments
+```
+
+### 2. Read the Quality Bar
+
+Read the gold-standard template and checklist:
+
+`.claude/skills/shared/issue-quality-checklist.md`
+
+### 3. Assess Quality
+
+Compare the issue against the quality checklist. For each checklist item, determine:
+
+- **Present and good**: The section exists and meets the bar
+- **Present but weak**: The section exists but needs improvement (explain why)
+- **Missing**: The section is absent entirely
+
+Present a concise assessment to the user, like:
+
+```
+Assessment of #35 — Environment variable manager:
+
+  Summary:            Good — clear what/why explanation
+  Subcommands:        Good — full table with descriptions
+  Architecture:       Good — domain, storage, security covered
+  Integration:        Good — connections to proj, vault, plugins
+  Acceptance criteria: Good — specific, testable checkboxes
+  Edge cases:         Weak — missing error handling for encryption failures
+  Tests:              Good — included in acceptance criteria
+  Documentation:      Good — specific file paths listed
+  CLAUDE.md update:   Good — noted
+  Labels:             Good — enhancement + phase:2
+
+Overall: 9/10 — Nearly gold standard. One gap identified.
+```
+
+### 4. Fill Gaps Through Conversation
+
+For each gap or weak area, ask **targeted questions** to gather the information needed.
+Don't just generate content — ask the user, since they have domain knowledge you don't.
+
+Examples of good questions:
+- "The acceptance criteria don't cover what happens when the encryption key is missing.
+  Should the command error with a specific message, prompt for key creation, or fall back
+  to unencrypted storage?"
+- "I don't see architecture notes. Where would this domain logic live — new package under
+  `internal/` or extension of an existing one?"
+- "The integration points section is missing. Does this feature connect to hooks, plugins,
+  or other commands?"
+
+Explore the codebase to make your questions more specific:
+- If the issue mentions a command, read the existing `cmd/` and `internal/` code to
+  understand the current state
+- If the issue mentions integration with another feature, check whether that feature
+  exists yet
+
+Ask 2-3 questions at a time, not all at once. Let the conversation flow naturally.
+
+### 5. Update the Issue
+
+Once the user is satisfied with the refinements, prepare the updated issue body.
+Show the full updated body for review, highlighting what changed.
+
+After approval, update the issue:
+
+```bash
+gh issue edit $ISSUE_NUMBER --body "<updated_body>"
+```
+
+Also suggest any label changes if appropriate (e.g., adding `agent-ready` if the issue
+is now well-defined enough for autonomous implementation).
+
+Always ask for explicit approval before running `gh issue edit`.
+
+## Guidelines
+
+- **Preserve existing good content.** Don't rewrite sections that already meet the bar.
+  Only add, improve, or restructure what's needed.
+- **Be conversational, not prescriptive.** Ask questions rather than generating assumptions.
+  The user knows their project better than you.
+- **Explore the codebase.** Ground your suggestions in actual code. If the issue mentions
+  `mine stash`, read the stash code to understand integration points.
+- **One round at a time.** Don't dump all suggestions at once. Assess, identify top gaps,
+  ask questions, iterate.
+- **Respect the user's intent.** If they wrote a terse issue on purpose (e.g., a quick
+  bug report), don't force it into the full template. Adapt the checklist to the issue type.
+- **Know when to stop.** If an issue already meets the bar, say so and celebrate it.
+  Not every issue needs refinement.

--- a/.claude/skills/shared/issue-quality-checklist.md
+++ b/.claude/skills/shared/issue-quality-checklist.md
@@ -1,0 +1,84 @@
+# Gold-Standard Issue Template
+
+This defines the quality bar for `mine` GitHub issues. Based on the format established
+by issue #35 (Environment variable manager). All backlog curation skills target this
+template as the output format.
+
+## Template
+
+```markdown
+## Summary
+
+One paragraph explaining what this feature/enhancement does and why it matters.
+Should answer: What problem does this solve? Who benefits? How does it fit into mine's vision?
+
+## Subcommands / Features
+
+| Command | Description |
+|---------|-------------|
+| `mine <cmd> <sub>` | What it does |
+| `mine <cmd> <sub> --flag` | What the flag changes |
+
+> Omit this section if the issue is a bug fix, refactor, or single-behavior enhancement.
+
+## Architecture / Design Notes
+
+- **Domain package**: `internal/<pkg>/` — where the core logic lives
+- **Storage**: SQLite table design, new migrations, or "no storage needed"
+- **Key technical decisions**: Libraries, algorithms, protocols
+- **Security considerations**: Input validation, encryption, access control
+- **Performance**: Anything that could affect the <50ms budget
+
+## Integration Points
+
+How this connects to existing mine features:
+- Which existing commands are affected?
+- Does it fire or consume hook events?
+- Does it interact with config, store, or plugins?
+- Are there dependencies on other planned features?
+
+## Acceptance Criteria
+
+- [ ] Specific, testable criterion that maps to one verifiable behavior
+- [ ] Another criterion — include happy path AND edge cases
+- [ ] Error handling: what happens when X fails?
+- [ ] Test requirements: unit tests for domain logic, integration tests if needed
+- [ ] Performance: command completes within the <50ms budget (if applicable)
+
+> Each checkbox should be independently verifiable. Avoid vague criteria like
+> "works correctly" — instead say "returns exit code 0 and prints confirmation message".
+
+## Documentation
+
+- [ ] User-facing docs: `docs/commands/<cmd>.md`
+- [ ] Internal specs (if complex): `docs/internal/specs/<feature>.md`
+- [ ] CLAUDE.md updates: new key files, architecture patterns, or lessons learned
+```
+
+## Quality Checklist
+
+When evaluating an issue, check each item:
+
+- [ ] **Summary**: Clear one-paragraph explanation of what and why
+- [ ] **Scope**: Features/subcommands enumerated (if applicable)
+- [ ] **Architecture**: Domain package, storage approach, key decisions documented
+- [ ] **Integration**: Connections to existing features identified
+- [ ] **Acceptance criteria**: Specific, testable checkboxes (not vague)
+- [ ] **Edge cases**: Error handling and failure modes covered in criteria
+- [ ] **Tests**: Test requirements included in acceptance criteria
+- [ ] **Documentation**: Doc requirements listed with specific file paths
+- [ ] **CLAUDE.md**: Update requirement noted for new patterns/key files
+- [ ] **Labels**: Appropriate labels applied (feature/enhancement, phase, etc.)
+
+## Label Guide
+
+| Label | When to use |
+|-------|-------------|
+| `feature` | Brand new capability (new command, new domain) |
+| `enhancement` | Improvement to existing feature |
+| `phase:1` | Foundation features (core CLI, config, store) |
+| `phase:2` | Growth features (craft, dig, shell, ai) |
+| `phase:3` | Advanced features (vault, grow, dash, plugins) |
+| `good-first-issue` | Clear scope, isolated domain, good for new contributors |
+| `spec` | Has a spec document in `docs/internal/specs/` |
+| `agent-ready` | Issue is well-defined enough for autonomous implementation |

--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,9 @@ Thumbs.db
 .env
 .env.*
 
-# Claude Code (user-local settings)
-.claude/
+# Claude Code (user-local settings, except repo-scoped skills)
+.claude/*
+!.claude/skills/
 .mcp.json
 
 # Vercel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,28 @@ Workflow:
 3. When ready to implement, create a branch from the issue
 4. Issues reference the spec; PRs reference the issue
 
+## Backlog Curation Skills
+
+Three Claude Code skills form a backlog curation pipeline. All are manual-invoke only
+(`disable-model-invocation: true`) since they create/update GitHub issues.
+
+| Skill | Purpose | Example |
+|-------|---------|---------|
+| `/brainstorm` | Generate feature ideas through codebase exploration | `/brainstorm todo`, `/brainstorm plugins` |
+| `/refine-issue` | Iteratively improve an existing issue via Q&A | `/refine-issue 35` |
+| `/draft-issue` | Turn a rough idea into a structured issue | `/draft-issue recurring todos` |
+
+All three target the gold-standard issue template (based on issue #35) defined in
+`.claude/skills/shared/issue-quality-checklist.md`. The template includes: summary,
+subcommands table, architecture notes, integration points, acceptance criteria, and
+documentation requirements.
+
+Key files:
+- `.claude/skills/brainstorm/SKILL.md` — feature ideation skill
+- `.claude/skills/refine-issue/SKILL.md` — issue refinement skill
+- `.claude/skills/draft-issue/SKILL.md` — issue drafting skill
+- `.claude/skills/shared/issue-quality-checklist.md` — shared quality template
+
 ## Lessons Learned
 
 ### L-001: Git config name parsing


### PR DESCRIPTION
## Summary

- Add three Claude Code skills (`/brainstorm`, `/refine-issue`, `/draft-issue`) that form a backlog curation pipeline for generating, refining, and drafting GitHub issues to a gold-standard quality bar
- Add shared issue quality checklist based on issue #35's format as the target template for all three skills
- Update `.gitignore` to allow `.claude/skills/` to be tracked while keeping other `.claude/*` files ignored

## Test plan

- [ ] Run `/brainstorm` — confirm it reads codebase context and generates ideas
- [ ] Run `/brainstorm todo` — confirm focus area filtering works
- [ ] Run `/refine-issue 35` — confirm it reads issue #35 and assesses quality
- [ ] Run `/draft-issue add a command to manage docker containers` — confirm it produces a full issue draft
- [ ] Verify all three skills appear in `/` autocomplete
- [ ] Verify none auto-invoke (all have `disable-model-invocation: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)