### PR TITLE
fix: pass review body via env var to prevent shell injection

### DIFF
--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -34,6 +34,10 @@ jobs:
         id: route
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass review body via env var to avoid shell injection — the body
+          # contains arbitrary text (code references, file paths) that would
+          # be interpreted as commands if interpolated directly into the script.
+          EVENT_REVIEW_BODY: ${{ github.event.review.body }}
         run: |
           # Resolve PR number based on event type
           if [ "${{ github.event_name }}" = "schedule" ]; then
@@ -180,7 +184,7 @@ jobs:
 
             # Check if review has actionable comments
             HAS_COMMENTS=false
-            REVIEW_BODY="${{ github.event.review.body }}"
+            REVIEW_BODY="$EVENT_REVIEW_BODY"
             if [ -n "$REVIEW_BODY" ] && [ "$REVIEW_BODY" != "null" ]; then
               HAS_COMMENTS=true
             fi


### PR DESCRIPTION
## Summary

- Fixes shell injection in `autodev-review-fix.yml` where `${{ github.event.review.body }}` was interpolated directly into a `run:` block, causing bash to execute Copilot review content (file paths, command names like `mine`, `config`, etc.) as shell commands
- Moves the review body to an `env:` block (`EVENT_REVIEW_BODY`) so GitHub Actions properly escapes it before bash runs

Discovered on PR #81 — the Copilot review body contained references to `mine ai`, `internal/ai/provider.go`, `config.toml`, etc., all of which bash tried to execute (exit code 127).

## Test plan

- [ ] Re-run autodev-review-fix on a PR with a Copilot review containing file paths and command-like text
- [ ] Verify the "Determine action" step no longer fails with "command not found" errors
- [ ] Verify the review body content is correctly checked for emptiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)