### PR TITLE
fix: add required name field to Claude skills

### DIFF
--- a/.claude/skills/brainstorm/SKILL.md
+++ b/.claude/skills/brainstorm/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: brainstorm
 description: "Generate feature and enhancement ideas for the mine CLI through codebase exploration and interactive discussion"
 disable-model-invocation: true
 ---

--- a/.claude/skills/draft-issue/SKILL.md
+++ b/.claude/skills/draft-issue/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: draft-issue
 description: "Turn a rough idea into a fully structured GitHub issue matching the gold-standard template"
 disable-model-invocation: true
 ---

--- a/.claude/skills/personality-audit/SKILL.md
+++ b/.claude/skills/personality-audit/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: personality-audit
 description: "Audit CLI output, docs, and site content for personality and tone consistency"
 disable-model-invocation: true
 ---

--- a/.claude/skills/refine-issue/SKILL.md
+++ b/.claude/skills/refine-issue/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: refine-issue
 description: "Iteratively refine a GitHub issue to the gold-standard quality bar through targeted Q&A"
 disable-model-invocation: true
 ---

--- a/.claude/skills/sweep-issues/SKILL.md
+++ b/.claude/skills/sweep-issues/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: sweep-issues
 description: "Sweep open issues against the quality checklist and label those needing refinement"
 disable-model-invocation: true
 ---


### PR DESCRIPTION
## Summary
- add missing `name` frontmatter to all five Claude skill `SKILL.md` files
- keeps existing descriptions and invocation settings unchanged

## Validation
- `make test`
- `make build`
