### PR TITLE
`debug.ReadBuildInfo()` enhancement

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,5 +1,7 @@
 package version
 
+import "runtime/debug"
+
 // Set at build time via ldflags.
 var (
 	Version = "dev"
@@ -13,4 +15,47 @@ func Full() string {
 
 func Short() string {
 	return Version
+}
+
+// init backfills Version, Commit, and Date from runtime/debug build info when
+// the ldflags defaults are still in place. ldflags values always take precedence.
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	backfillFromBuildInfo(info)
+}
+
+// backfillFromBuildInfo fills in Version, Commit, and Date from the provided
+// BuildInfo when the respective variable still holds its ldflag default value.
+// This allows `go install` builds to show real version info without requiring
+// ldflags to be passed.
+func backfillFromBuildInfo(info *debug.BuildInfo) {
+	if info == nil {
+		return
+	}
+
+	// Only set Version if still at default and build info has a real tagged version.
+	// When built from HEAD without a tag, info.Main.Version == "(devel)" — keep "dev".
+	if Version == "dev" && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		Version = info.Main.Version
+	}
+
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			if Commit == "none" && s.Value != "" {
+				rev := s.Value
+				if len(rev) > 7 {
+					rev = rev[:7]
+				}
+				Commit = rev
+			}
+		case "vcs.time":
+			if Date == "unknown" && s.Value != "" {
+				Date = s.Value
+			}
+		}
+	}
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"runtime/debug"
 	"strings"
 	"testing"
 )
@@ -20,4 +21,152 @@ func TestShort(t *testing.T) {
 	if result != Version {
 		t.Errorf("Short() = %q, want %q", result, Version)
 	}
+}
+
+// withDefaults runs fn with Version, Commit, and Date reset to their ldflag
+// defaults, restoring the original values when fn returns.
+func withDefaults(fn func()) {
+	origVersion, origCommit, origDate := Version, Commit, Date
+	Version, Commit, Date = "dev", "none", "unknown"
+	defer func() {
+		Version, Commit, Date = origVersion, origCommit, origDate
+	}()
+	fn()
+}
+
+func buildInfo(mainVersion string, settings map[string]string) *debug.BuildInfo {
+	info := &debug.BuildInfo{
+		Main: debug.Module{Version: mainVersion},
+	}
+	for k, v := range settings {
+		info.Settings = append(info.Settings, debug.BuildSetting{Key: k, Value: v})
+	}
+	return info
+}
+
+// TestBackfillFromBuildInfo_AllDefaults verifies that when all three vars are at
+// their ldflag defaults, backfillFromBuildInfo fills them from build info.
+func TestBackfillFromBuildInfo_AllDefaults(t *testing.T) {
+	withDefaults(func() {
+		info := buildInfo("v0.1.0", map[string]string{
+			"vcs.revision": "abcdef1234567",
+			"vcs.time":     "2024-01-15T10:00:00Z",
+		})
+		backfillFromBuildInfo(info)
+
+		if Version != "v0.1.0" {
+			t.Errorf("Version = %q, want %q", Version, "v0.1.0")
+		}
+		if Commit != "abcdef1" {
+			t.Errorf("Commit = %q, want %q", Commit, "abcdef1")
+		}
+		if Date != "2024-01-15T10:00:00Z" {
+			t.Errorf("Date = %q, want %q", Date, "2024-01-15T10:00:00Z")
+		}
+	})
+}
+
+// TestBackfillFromBuildInfo_LdflagsPrecedence verifies that non-default ldflag
+// values are not overwritten by backfillFromBuildInfo.
+func TestBackfillFromBuildInfo_LdflagsPrecedence(t *testing.T) {
+	origVersion, origCommit, origDate := Version, Commit, Date
+	defer func() {
+		Version, Commit, Date = origVersion, origCommit, origDate
+	}()
+
+	// Simulate ldflags having already set real values.
+	Version = "v1.2.3"
+	Commit = "deadbee"
+	Date = "2025-06-01T00:00:00Z"
+
+	info := buildInfo("v0.0.1", map[string]string{
+		"vcs.revision": "aaaaaaa",
+		"vcs.time":     "2000-01-01T00:00:00Z",
+	})
+	backfillFromBuildInfo(info)
+
+	if Version != "v1.2.3" {
+		t.Errorf("Version overwritten: got %q, want %q", Version, "v1.2.3")
+	}
+	if Commit != "deadbee" {
+		t.Errorf("Commit overwritten: got %q, want %q", Commit, "deadbee")
+	}
+	if Date != "2025-06-01T00:00:00Z" {
+		t.Errorf("Date overwritten: got %q, want %q", Date, "2025-06-01T00:00:00Z")
+	}
+}
+
+// TestBackfillFromBuildInfo_DevelVersion verifies that when info.Main.Version is
+// "(devel)" (built from HEAD without a tag), Version stays "dev" but Commit and
+// Date are still populated from VCS stamps.
+func TestBackfillFromBuildInfo_DevelVersion(t *testing.T) {
+	withDefaults(func() {
+		info := buildInfo("(devel)", map[string]string{
+			"vcs.revision": "cafebabe1234",
+			"vcs.time":     "2025-02-21T08:30:00Z",
+		})
+		backfillFromBuildInfo(info)
+
+		if Version != "dev" {
+			t.Errorf("Version = %q, want %q (devel should keep 'dev')", Version, "dev")
+		}
+		if Commit != "cafebab" {
+			t.Errorf("Commit = %q, want %q", Commit, "cafebab")
+		}
+		if Date != "2025-02-21T08:30:00Z" {
+			t.Errorf("Date = %q, want %q", Date, "2025-02-21T08:30:00Z")
+		}
+	})
+}
+
+// TestBackfillFromBuildInfo_NilInfo verifies that passing nil does not panic
+// and leaves variables unchanged.
+func TestBackfillFromBuildInfo_NilInfo(t *testing.T) {
+	withDefaults(func() {
+		backfillFromBuildInfo(nil)
+
+		if Version != "dev" {
+			t.Errorf("Version changed on nil info: %q", Version)
+		}
+		if Commit != "none" {
+			t.Errorf("Commit changed on nil info: %q", Commit)
+		}
+		if Date != "unknown" {
+			t.Errorf("Date changed on nil info: %q", Date)
+		}
+	})
+}
+
+// TestBackfillFromBuildInfo_ShortRevision verifies that short revisions (≤7 chars)
+// are kept as-is rather than being truncated.
+func TestBackfillFromBuildInfo_ShortRevision(t *testing.T) {
+	withDefaults(func() {
+		info := buildInfo("v0.2.0", map[string]string{
+			"vcs.revision": "abc123",
+		})
+		backfillFromBuildInfo(info)
+
+		if Commit != "abc123" {
+			t.Errorf("Commit = %q, want %q", Commit, "abc123")
+		}
+	})
+}
+
+// TestBackfillFromBuildInfo_EmptyVCS verifies that missing VCS settings leave
+// Commit and Date at their defaults.
+func TestBackfillFromBuildInfo_EmptyVCS(t *testing.T) {
+	withDefaults(func() {
+		info := buildInfo("v0.3.0", nil)
+		backfillFromBuildInfo(info)
+
+		if Version != "v0.3.0" {
+			t.Errorf("Version = %q, want v0.3.0", Version)
+		}
+		if Commit != "none" {
+			t.Errorf("Commit = %q, want none (no VCS setting)", Commit)
+		}
+		if Date != "unknown" {
+			t.Errorf("Date = %q, want unknown (no VCS setting)", Date)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

When `mine` is installed via `go install github.com/rnwolfe/mine@v0.1.0`, no `-ldflags` are injected, so `mine version` previously showed `mine dev (none) unknown`. Go's `runtime/debug.ReadBuildInfo()` exposes the module version and VCS stamps embedded at build time. This PR adds an `init()` fallback that reads that data and backfills `Version`, `Commit`, and `Date` only when their ldflag defaults are still in place, so `go install` builds display real version info without any changes to the release pipeline.

Closes #98

## Changes

- **Modified files**:
  - `internal/version/version.go` — Added `init()` that calls `debug.ReadBuildInfo()` and delegates to the new unexported `backfillFromBuildInfo(*debug.BuildInfo)` helper. ldflags values always take precedence (variables are only updated when still at their default values `"dev"`, `"none"`, `"unknown"`). The `(devel)` sentinel from HEAD builds keeps `Version = "dev"` but still populates `Commit` and `Date` from VCS stamps.
  - `internal/version/version_test.go` — Replaced minimal placeholder tests with comprehensive coverage of `backfillFromBuildInfo` and kept the existing `TestFull`/`TestShort` tests.

- **Architecture**: The backfill logic is extracted into `backfillFromBuildInfo` (unexported, same package) so it can be exercised directly in tests without re-running `init()`. A `withDefaults` test helper temporarily resets the package-level vars to their defaults and restores them after each test case, enabling isolated and repeatable assertions.

## CLI Surface

No new commands or flags. `mine version` output is unchanged in structure; it now shows real data for `go install` builds.

## Test Coverage

- `TestBackfillFromBuildInfo_AllDefaults` — all three vars at defaults; verifies Version, Commit (truncated to 7 chars), and Date are populated from build info
- `TestBackfillFromBuildInfo_LdflagsPrecedence` — non-default ldflag values are not overwritten
- `TestBackfillFromBuildInfo_DevelVersion` — `(devel)` main version keeps `Version = "dev"` but still sets Commit and Date from VCS stamps
- `TestBackfillFromBuildInfo_NilInfo` — nil input does not panic, vars remain unchanged
- `TestBackfillFromBuildInfo_ShortRevision` — revisions ≤ 7 chars are kept as-is rather than truncated
- `TestBackfillFromBuildInfo_EmptyVCS` — missing VCS settings leave Commit and Date at defaults
- `TestFull` / `TestShort` — existing tests retained

## Acceptance Criteria

- [x] `mine version` shows module version (e.g. `v0.1.0`) when installed via `go install ...@v0.1.0` — met by backfilling `Version` from `info.Main.Version` when still `"dev"`
- [x] `mine version` shows short commit hash when installed via `go install ...@<commitsha>` — met by backfilling `Commit` from `vcs.revision` (truncated to 7 chars) when still `"none"`
- [x] GoReleaser release builds (with ldflags) are unaffected — ldflags values take precedence because backfill only fires when vars equal their defaults
- [x] When `go install` is from `main`/HEAD (`(devel)`), `Version` stays `"dev"` but `Commit` and `Date` are populated from VCS stamps — guarded by `info.Main.Version != "(devel)"` check
- [x] If `debug.ReadBuildInfo()` returns `false`, existing defaults remain unchanged — early return on `!ok` in `init()`
- [x] Unit tests cover: fallback when all three vars are at defaults, ldflags precedence, `(devel)` version handling, nil info safety, short revision, empty VCS settings

<!-- autodev-state: {"phase": "copilot", "copilot_iterations": 1} -->