### PR TITLE
feat: mine env edit — bulk edit encrypted env profile in $EDITOR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Rules:
     Profile files are age-encrypted JSON stored at `$XDG_DATA_HOME/mine/envs/<sha256(project_path)>/<profile>.age`.
     Active profile per project is tracked in the `env_projects` SQLite table (defaults to `local`).
     Passphrase sourced from `MINE_ENV_PASSPHRASE`, `MINE_VAULT_PASSPHRASE`, or TTY prompt — never stored.
-    CLI: `mine env show/set/unset/diff/switch/export/template/inject`. Shell helper: `menv`.
+    CLI: `mine env show/set/unset/diff/switch/export/template/inject/edit`. Shell helper: `menv`.
 13. **Project context registry**: `internal/proj` persists project membership in SQLite
     (`projects` table) and project-local settings in `~/.config/mine/projects.toml`.
     Current/previous project pointers are tracked via `kv` keys (`proj.current`,
@@ -530,7 +530,7 @@ that mode, or the picker can become invisible/hang despite stdin being interacti
 | `internal/tmux/tmux.go` | Tmux session management (list, new, attach, kill) |
 | `internal/tmux/layout.go` | Layout persistence (save/load/list, TOML in XDG config) |
 | `cmd/tmux.go` | Tmux CLI commands with TUI picker integration |
-| `cmd/env.go` | Env CLI commands (show, set, unset, diff, switch, export, template, inject) |
+| `cmd/env.go` | Env CLI commands (show, set, unset, diff, switch, export, template, inject, edit) |
 | `internal/env/env.go` | Env manager: profile CRUD, age encryption/decryption, active profile tracking, diff, export |
 | `scripts/autodev/config.sh` | Autodev shared constants, logging, utilities |
 | `scripts/autodev/pick-issue.sh` | Issue selection with concurrency guard |

--- a/site/src/content/docs/commands/env.md
+++ b/site/src/content/docs/commands/env.md
@@ -57,6 +57,25 @@ mine env unset API_TOKEN
 
 Removes a variable from the active profile permanently.
 
+## Edit Profile in $EDITOR
+
+```bash
+mine env edit
+mine env edit staging
+```
+
+Decrypts the active profile (or a named profile) to a secure temp file and opens it in `$EDITOR`. On clean editor exit, the file is re-encrypted and saved. The temp file is removed on all exit paths — success, editor error, or save error.
+
+The temp file format is sorted `KEY=VALUE` lines (one per variable). Blank lines and lines starting with `#` are ignored on re-read.
+
+| Behaviour | Detail |
+|-----------|--------|
+| `$EDITOR` not set | Non-zero exit with hint to set `EDITOR` or use `mine env set` |
+| Editor exits non-zero | Changes discarded; original profile unchanged |
+| Invalid key in edited file | Changes discarded; all invalid keys listed in error |
+| Named profile does not exist | Non-zero exit — profile must exist before editing |
+| Temp file permissions | `0600` — owner read/write only |
+
 ## Compare Profiles
 
 ```bash
@@ -148,6 +167,8 @@ On fish, `menv` automatically uses fish-compatible export syntax. In all shells,
 | Missing profile on `switch` | Non-zero exit, profile name in error |
 | No passphrase in non-interactive mode | Non-zero exit, instructive error |
 | Invalid key name | Non-zero exit before any disk writes |
+| `$EDITOR` not set (`env edit`) | Non-zero exit with fallback hint |
+| Editor exits non-zero (`env edit`) | Non-zero exit; original profile unchanged |
 
 ## Storage Location
 


### PR DESCRIPTION
## Summary

Implements `mine env edit [profile]` (closes #122), filling the gap left after PR #121 shipped the full `mine env` surface without `edit`. Without it, bulk-editing a profile requires multiple `mine env set` calls.

- Decrypts the active (or named) profile to a secure temp file (`0600`, `os.TempDir`), opens `$EDITOR`, then re-encrypts and saves on clean exit
- Temp file is removed on **all** exit paths — success, editor error, parse error, and save error
- Blank lines and `# comments` are ignored on re-read
- Variables are written sorted alphabetically

## Acceptance Criteria

Verified against issue #122:

- [x] `mine env edit` opens the active profile in `$EDITOR`; saves re-encrypted on clean editor exit — `runEnvEdit` resolves active profile via `ActiveProfile()`, writes temp, opens editor, saves on clean exit
- [x] `mine env edit <profile>` opens the named profile — `args[0]` branch in `runEnvEdit`
- [x] Temp file created with `0600` permissions in `os.TempDir()` — `os.CreateTemp(os.TempDir(), "mine-env-*.env")` + `os.Chmod(tmpName, 0o600)`
- [x] Temp file removed on all exit paths — `defer os.Truncate + os.Remove`
- [x] If `$EDITOR` is not set, print actionable error with fallback hint — early return before `envManager()` with `mine env set` fallback
- [x] If editor exits non-zero, abort with error; original profile is unchanged — `editorCmd.Run()` error path returns early before `SaveProfile`
- [x] If any edited key fails `env.ValidateKey`, abort with error listing the invalid keys — `parseEnvFile` collects all invalid keys and returns them before any save
- [x] If named profile does not exist, error clearly — `os.ErrNotExist` check in `LoadProfile` returns descriptive error
- [x] `envEditCmd` is wrapped with `hook.Wrap("env.edit", ...)` — yes
- [x] Unit tests in `internal/env/` cover: edit round-trip, invalid key rejection — `TestEditRoundTrip`, `TestSaveProfileRejectsInvalidKey`
- [x] Integration tests in `cmd/` cover: missing `$EDITOR`, invalid key in edited file — `TestRunEnvEditMissingEditor`, `TestParseEnvFileInvalidKey`; non-zero editor exit is a trivial error propagation from `cmd.Run()`
- [x] CLAUDE.md architecture pattern #12 updated to include `edit` — updated both CLI surface list and key files table
- [x] `site/src/content/docs/commands/env.md` updated — new "Edit Profile in \$EDITOR" section + error table rows

## Test plan

- [x] `make build` passes
- [x] `make test` passes (all existing tests green)
- [x] 7 new tests all pass: `TestRunEnvEditMissingEditor`, `TestParseEnvFileValid`, `TestParseEnvFileInvalidKey`, `TestParseEnvFileIgnoresBlankAndComments`, `TestParseEnvFileValueWithEquals`, `TestEditRoundTrip`, `TestSaveProfileRejectsInvalidKey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)