### PR TITLE
feat: add mine env edit — bulk profile editing in $EDITOR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Rules:
     Profile files are age-encrypted JSON stored at `$XDG_DATA_HOME/mine/envs/<sha256(project_path)>/<profile>.age`.
     Active profile per project is tracked in the `env_projects` SQLite table (defaults to `local`).
     Passphrase sourced from `MINE_ENV_PASSPHRASE`, `MINE_VAULT_PASSPHRASE`, or TTY prompt — never stored.
-    CLI: `mine env show/set/unset/diff/switch/export/template/inject`. Shell helper: `menv`.
+    CLI: `mine env show/set/unset/diff/switch/export/template/inject/edit`. Shell helper: `menv`.
 13. **Project context registry**: `internal/proj` persists project membership in SQLite
     (`projects` table) and project-local settings in `~/.config/mine/projects.toml`.
     Current/previous project pointers are tracked via `kv` keys (`proj.current`,

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -79,6 +80,106 @@ func TestParseSetArgRequiresValue(t *testing.T) {
 	_, _, err = parseSetArg("TOKEN")
 	if err == nil || !strings.Contains(err.Error(), "value") {
 		t.Fatalf("expected value required error, got %v", err)
+	}
+}
+
+func TestRunEnvEditMissingEditor(t *testing.T) {
+	t.Setenv("EDITOR", "")
+
+	err := runEnvEdit(nil, nil)
+	if err == nil {
+		t.Fatal("expected error when $EDITOR is not set")
+	}
+	if !strings.Contains(err.Error(), "EDITOR") {
+		t.Errorf("error should mention EDITOR, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "mine env set") {
+		t.Errorf("error should mention fallback command, got: %v", err)
+	}
+}
+
+func TestParseEnvFile(t *testing.T) {
+	content := "# comment\nAPI_KEY=secret\nPORT=8080\nEMPTY=\nMULTI=a=b=c\n"
+	vars, invalidKeys := parseEnvFile(content)
+	if len(invalidKeys) != 0 {
+		t.Fatalf("unexpected invalid keys: %v", invalidKeys)
+	}
+	if vars["API_KEY"] != "secret" {
+		t.Errorf("API_KEY: got %q", vars["API_KEY"])
+	}
+	if vars["PORT"] != "8080" {
+		t.Errorf("PORT: got %q", vars["PORT"])
+	}
+	if vars["EMPTY"] != "" {
+		t.Errorf("EMPTY: got %q", vars["EMPTY"])
+	}
+	if vars["MULTI"] != "a=b=c" {
+		t.Errorf("MULTI: got %q", vars["MULTI"])
+	}
+}
+
+func TestParseEnvFileInvalidKeys(t *testing.T) {
+	content := "VALID=ok\nINVALID-KEY=bad\n123_STARTS_NUM=bad\n"
+	vars, invalidKeys := parseEnvFile(content)
+	if _, ok := vars["VALID"]; !ok {
+		t.Error("VALID key should be in result")
+	}
+	if len(invalidKeys) != 2 {
+		t.Fatalf("expected 2 invalid keys, got %v", invalidKeys)
+	}
+}
+
+func TestRunEnvEditEditorNonzeroExit(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmpDir, "data"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state"))
+	t.Setenv("MINE_ENV_PASSPHRASE", "test-pass")
+	t.Chdir(tmpDir)
+
+	// Create a fake editor that exits non-zero.
+	editorScript := filepath.Join(tmpDir, "bad-editor.sh")
+	if err := os.WriteFile(editorScript, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile editor script: %v", err)
+	}
+	t.Setenv("EDITOR", editorScript)
+
+	err := runEnvEdit(nil, nil)
+	if err == nil {
+		t.Fatal("expected error from editor non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "no changes saved") {
+		t.Errorf("error should mention no changes saved, got: %v", err)
+	}
+}
+
+func TestRunEnvEditInvalidKeyInFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmpDir, "data"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpDir, "cache"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(tmpDir, "state"))
+	t.Setenv("MINE_ENV_PASSPHRASE", "test-pass")
+	t.Chdir(tmpDir)
+
+	// Create a fake editor that writes an invalid key.
+	editorScript := filepath.Join(tmpDir, "invalid-editor.sh")
+	script := "#!/bin/sh\nprintf 'INVALID-KEY=value\\n' > \"$1\"\n"
+	if err := os.WriteFile(editorScript, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile editor script: %v", err)
+	}
+	t.Setenv("EDITOR", editorScript)
+
+	err := runEnvEdit(nil, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid key in edited file")
+	}
+	if !strings.Contains(err.Error(), "INVALID-KEY") {
+		t.Errorf("error should name the invalid key, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "No changes saved") {
+		t.Errorf("error should mention no changes saved, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Implements `mine env edit [profile]` to open an encrypted env profile in `$EDITOR` for bulk editing
- Fills the UX gap from PR #121 — without this, bulk-editing requires multiple `mine env set` calls
- Follows the existing `config edit` pattern (`cmd/config.go:174`) exactly

## Implementation

The edit flow:
1. Decrypt profile → write sorted `KEY=VALUE` temp file (`0600` perms in `os.TempDir()`)
2. Open `$EDITOR` (split on whitespace, consistent with `mine config edit`)
3. Re-parse edited file (skip blank lines and `#` comments)
4. Validate all keys via `env.ValidateKey` — collect all invalid keys before aborting
5. Re-encrypt and save via `SaveProfile`
6. Temp file zero-filled then removed on all exit paths (success, editor error, parse error, save error)

**Safety guarantees:**
- Editor exits non-zero → original profile unchanged, clear error message
- Any invalid key in edited file → all changes discarded, lists the bad keys
- Named profile doesn't exist → error (no silent blank profile creation)
- `$EDITOR` not set → actionable error with `export EDITOR=vim` hint and `mine env set` fallback

## Acceptance Criteria

Verified against issue #122:

- [x] `mine env edit` opens the active profile in `$EDITOR`; saves re-encrypted on clean editor exit
- [x] `mine env edit <profile>` opens the named profile
- [x] Temp file created with `0600` permissions in `os.TempDir()`
- [x] Temp file removed on all exit paths (success, editor error, parse error, save error)
- [x] If `$EDITOR` is not set, actionable error with `export EDITOR=vim` hint and `mine env set` fallback
- [x] If editor exits non-zero, abort with error; original profile unchanged
- [x] If any edited key fails `ValidateKey`, abort listing all invalid keys; original profile unchanged
- [x] If named profile does not exist, error clearly
- [x] `envEditCmd` wrapped with `hook.Wrap("env.edit", ...)`
- [x] Unit tests in `internal/env/`: edit round-trip and invalid key rejection
- [x] Integration tests in `cmd/env_test.go`: missing `$EDITOR`, non-zero editor exit, invalid key in file
- [x] `site/src/content/docs/commands/env.md` updated with `edit` subcommand and error table entries
- [x] `CLAUDE.md` architecture pattern #12 updated to include `edit` in CLI surface

Fixes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)