### PR TITLE
fix: enforce hook.Wrap across all Cobra command handlers

### DIFF
--- a/cmd/about.go
+++ b/cmd/about.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/rnwolfe/mine/internal/hook"
 	"github.com/rnwolfe/mine/internal/ui"
 	"github.com/rnwolfe/mine/internal/version"
 	"github.com/spf13/cobra"
@@ -12,10 +13,10 @@ var aboutCmd = &cobra.Command{
 	Use:   "about",
 	Short: "The story, the version, the vibe",
 	Long:  "Everything you ever wanted to know about mine — who made it, what it does, and why it exists.",
-	Run:   runAbout,
+	RunE:  hook.Wrap("about", runAbout),
 }
 
-func runAbout(_ *cobra.Command, _ []string) {
+func runAbout(_ *cobra.Command, _ []string) error {
 	fmt.Println()
 	fmt.Println(ui.Title.Render("  " + ui.IconGem + " mine"))
 	fmt.Println(ui.Muted.Render("  ────────────────────────────────────────────"))
@@ -34,4 +35,5 @@ func runAbout(_ *cobra.Command, _ []string) {
 	fmt.Println()
 	ui.Tip("run `mine help` to explore everything mine can do")
 	fmt.Println()
+	return nil
 }

--- a/cmd/about_test.go
+++ b/cmd/about_test.go
@@ -15,7 +15,9 @@ func TestAboutCommand(t *testing.T) {
 	os.Stdout = w
 
 	// Run the command
-	runAbout(nil, nil)
+	if err := runAbout(nil, nil); err != nil {
+		t.Fatalf("runAbout: %v", err)
+	}
 
 	// Restore stdout
 	w.Close()

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -12,13 +12,13 @@ var hookCmd = &cobra.Command{
 	Use:   "hook",
 	Short: "Automate mine with event-driven scripts",
 	Long:  `Create scripts that fire before or after any mine command. Drop them in ~/.config/mine/hooks/.`,
-	RunE:  runHookList,
+	RunE:  hook.Wrap("hook", runHookList),
 }
 
 var hookListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all active hook scripts",
-	RunE:  runHookList,
+	RunE:  hook.Wrap("hook.list", runHookList),
 }
 
 var hookCreateCmd = &cobra.Command{
@@ -31,14 +31,14 @@ Examples:
   mine hook create "todo.*" notify
   mine hook create "*" postexec`,
 	Args: cobra.ExactArgs(2),
-	RunE: runHookCreate,
+	RunE: hook.Wrap("hook.create", runHookCreate),
 }
 
 var hookTestCmd = &cobra.Command{
 	Use:   "test <file>",
 	Short: "Dry-run a hook with sample input to verify it works",
 	Args:  cobra.ExactArgs(1),
-	RunE:  runHookTest,
+	RunE:  hook.Wrap("hook.test", runHookTest),
 }
 
 func init() {

--- a/cmd/hook_wrap_test.go
+++ b/cmd/hook_wrap_test.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/rnwolfe/mine/internal/hook"
+	"github.com/spf13/cobra"
+)
+
+// hookWrapTestEnv sets up an isolated XDG environment for the test.
+func hookWrapTestEnv(t *testing.T) {
+	t.Helper()
+	configTestEnv(t)
+}
+
+// makeCounter returns a hook.Handler that increments an atomic counter on each call.
+func makeCounter(n *atomic.Int32) hook.Handler {
+	return func(ctx *hook.Context) (*hook.Context, error) {
+		n.Add(1)
+		return ctx, nil
+	}
+}
+
+// stubCmd returns a minimal cobra.Command suitable for passing to wrapped handlers in tests.
+func stubCmd() *cobra.Command {
+	return &cobra.Command{Use: "test"}
+}
+
+func TestHookWrap_VersionFiresHook(t *testing.T) {
+	hookWrapTestEnv(t)
+
+	reg := &hook.Registry{}
+	var called atomic.Int32
+	if err := reg.Register(hook.Hook{
+		Pattern: "version",
+		Stage:   hook.StagePreexec,
+		Mode:    hook.ModeTransform,
+		Name:    "test-version-hook",
+		Source:  "test",
+		Handler: makeCounter(&called),
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	wrapped := hook.WrapWith(reg, "version", runVersion)
+	if err := wrapped(stubCmd(), nil); err != nil {
+		t.Fatalf("wrapped runVersion: %v", err)
+	}
+
+	if called.Load() != 1 {
+		t.Errorf("hook called %d times, want 1", called.Load())
+	}
+}
+
+func TestHookWrap_AboutFiresHook(t *testing.T) {
+	hookWrapTestEnv(t)
+
+	reg := &hook.Registry{}
+	var called atomic.Int32
+	if err := reg.Register(hook.Hook{
+		Pattern: "about",
+		Stage:   hook.StagePreexec,
+		Mode:    hook.ModeTransform,
+		Name:    "test-about-hook",
+		Source:  "test",
+		Handler: makeCounter(&called),
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	wrapped := hook.WrapWith(reg, "about", runAbout)
+	if err := wrapped(stubCmd(), nil); err != nil {
+		t.Fatalf("wrapped runAbout: %v", err)
+	}
+
+	if called.Load() != 1 {
+		t.Errorf("hook called %d times, want 1", called.Load())
+	}
+}
+
+func TestHookWrap_PluginListFiresHook(t *testing.T) {
+	hookWrapTestEnv(t)
+
+	reg := &hook.Registry{}
+	var called atomic.Int32
+	if err := reg.Register(hook.Hook{
+		Pattern: "plugin.list",
+		Stage:   hook.StagePreexec,
+		Mode:    hook.ModeTransform,
+		Name:    "test-plugin-list-hook",
+		Source:  "test",
+		Handler: makeCounter(&called),
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	wrapped := hook.WrapWith(reg, "plugin.list", runPluginList)
+	if err := wrapped(stubCmd(), nil); err != nil {
+		t.Fatalf("wrapped runPluginList: %v", err)
+	}
+
+	if called.Load() != 1 {
+		t.Errorf("hook called %d times, want 1", called.Load())
+	}
+}
+
+func TestHookWrap_HookListFiresHook(t *testing.T) {
+	hookWrapTestEnv(t)
+
+	reg := &hook.Registry{}
+	var called atomic.Int32
+	if err := reg.Register(hook.Hook{
+		Pattern: "hook.list",
+		Stage:   hook.StagePreexec,
+		Mode:    hook.ModeTransform,
+		Name:    "test-hook-list-hook",
+		Source:  "test",
+		Handler: makeCounter(&called),
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	wrapped := hook.WrapWith(reg, "hook.list", runHookList)
+	if err := wrapped(stubCmd(), nil); err != nil {
+		t.Fatalf("wrapped runHookList: %v", err)
+	}
+
+	if called.Load() != 1 {
+		t.Errorf("hook called %d times, want 1", called.Load())
+	}
+}
+
+func TestHookWrap_NoHooksRegistered_StillRuns(t *testing.T) {
+	hookWrapTestEnv(t)
+
+	// Empty registry — fast path must still execute the command without hooks.
+	reg := &hook.Registry{}
+
+	wrapped := hook.WrapWith(reg, "version", runVersion)
+	if err := wrapped(stubCmd(), nil); err != nil {
+		t.Fatalf("wrapped runVersion (no hooks): %v", err)
+	}
+}

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/rnwolfe/mine/internal/hook"
 	"github.com/rnwolfe/mine/internal/plugin"
 	"github.com/rnwolfe/mine/internal/ui"
 	"github.com/spf13/cobra"
@@ -18,20 +19,20 @@ var pluginCmd = &cobra.Command{
 	Use:   "plugin",
 	Short: "Manage plugins",
 	Long:  `Install, remove, and manage mine plugins from GitHub repositories.`,
-	RunE:  runPluginList,
+	RunE:  hook.Wrap("plugin", runPluginList),
 }
 
 var pluginListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List installed plugins",
-	RunE:  runPluginList,
+	RunE:  hook.Wrap("plugin.list", runPluginList),
 }
 
 var pluginInfoCmd = &cobra.Command{
 	Use:   "info <name>",
 	Short: "Show detailed plugin info",
 	Args:  cobra.ExactArgs(1),
-	RunE:  runPluginInfo,
+	RunE:  hook.Wrap("plugin.info", runPluginInfo),
 }
 
 var pluginInstallCmd = &cobra.Command{
@@ -43,7 +44,7 @@ Examples:
   mine plugin install ./my-plugin
   mine plugin install /path/to/mine-plugin-obsidian`,
 	Args: cobra.ExactArgs(1),
-	RunE: runPluginInstall,
+	RunE: hook.Wrap("plugin.install", runPluginInstall),
 }
 
 var pluginRemoveCmd = &cobra.Command{
@@ -51,14 +52,14 @@ var pluginRemoveCmd = &cobra.Command{
 	Aliases: []string{"rm", "uninstall"},
 	Short:   "Remove an installed plugin",
 	Args:    cobra.ExactArgs(1),
-	RunE:    runPluginRemove,
+	RunE:    hook.Wrap("plugin.remove", runPluginRemove),
 }
 
 var pluginSearchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search GitHub for mine plugins",
 	Args:  cobra.MaximumNArgs(1),
-	RunE:  runPluginSearch,
+	RunE:  hook.Wrap("plugin.search", runPluginSearch),
 }
 
 var pluginSearchTag string

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/rnwolfe/mine/internal/hook"
 	"github.com/rnwolfe/mine/internal/version"
 	"github.com/spf13/cobra"
 )
@@ -14,13 +15,16 @@ var (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print mine version",
-	Run: func(_ *cobra.Command, _ []string) {
-		if versionShort {
-			fmt.Println(version.Short())
-		} else {
-			fmt.Printf("mine %s\n", version.Full())
-		}
-	},
+	RunE:  hook.Wrap("version", runVersion),
+}
+
+func runVersion(_ *cobra.Command, _ []string) error {
+	if versionShort {
+		fmt.Println(version.Short())
+	} else {
+		fmt.Printf("mine %s\n", version.Full())
+	}
+	return nil
 }
 
 func init() {

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -51,7 +51,9 @@ func TestVersionCommand(t *testing.T) {
 			os.Stdout = w
 
 			// Run the command directly (flag is already set by ParseFlags)
-			versionCmd.Run(nil, nil)
+			if err := runVersion(nil, nil); err != nil {
+				t.Fatalf("runVersion: %v", err)
+			}
 
 			// Restore stdout
 			w.Close()

--- a/site/src/content/docs/contributors/architecture.md
+++ b/site/src/content/docs/contributors/architecture.md
@@ -67,6 +67,16 @@ Files in `cmd/` are orchestration only. They:
 
 They do **not** contain business logic or direct database queries.
 
+**Hook wrapping is mandatory.** Every Cobra command handler must use `RunE` (not `Run`) and be wrapped with `hook.Wrap`:
+
+```go
+var myCmd = &cobra.Command{
+    RunE: hook.Wrap("domain.subcommand", runMyCommand),
+}
+```
+
+This ensures all commands are observable and extensible by plugins and user hooks. A command that bypasses `hook.Wrap` breaks the extensibility guarantee. The hook name must follow the `domain.subcommand` convention (e.g. `plugin.install`, `todo.add`).
+
 ```mermaid
 sequenceDiagram
     User->>cmd: mine todo add "task"


### PR DESCRIPTION
## Summary

- Wraps all `plugin.*`, `hook.*`, `version`, and `about` command handlers with `hook.Wrap` so they participate fully in the hook pipeline
- Converts `Run` to `RunE` for `version` and `about` (following project-wide policy)
- Adds `cmd/hook_wrap_test.go` with hook execution tests for each previously-unwrapped command group
- Documents the mandatory `hook.Wrap` rule in `site/src/content/docs/contributors/architecture.md`

## Acceptance Criteria

Verified against issue #114:
- [x] All command handlers in `cmd/` use `RunE` + `hook.Wrap(...)` — `plugin`, `hook`, `version`, `about` now wrapped
- [x] `plugin`, `plugin list`, `plugin info`, `plugin install`, `plugin remove`, `plugin search` are hook-wrapped
- [x] `hook`, `hook list`, `hook create`, `hook test` are hook-wrapped
- [x] `version` and `about` converted from `Run` to hook-wrapped `RunE` handlers
- [x] Hook names follow `domain.subcommand` convention
- [x] Existing command output/behavior unchanged (all existing tests pass)
- [x] Tests added to verify hook execution for `plugin.list`, `hook.list`, `version`, and `about`
- [x] Architecture doc updated with mandatory hook.Wrap rule

## Test plan

- [x] `go test ./...` — all 23 packages pass
- [x] `make build` — binary compiles cleanly
- [x] `TestHookWrap_*` — five new tests confirm hooks fire and the no-hook fast path still works

Fixes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)