### PR TITLE
feat: product skill, lifecycle map, and autodev skill

### DIFF
--- a/.claude/skills/autodev-audit/SKILL.md
+++ b/.claude/skills/autodev-audit/SKILL.md
@@ -27,7 +27,7 @@ Examples:
 Fetch recent autodev PRs (default last 5, or user-specified limit):
 
 ```bash
-gh pr list --repo rnwolfe/mine --label autodev --state all --limit <N> \
+gh pr list --repo rnwolfe/mine --label via/autodev --state all --limit <N> \
   --json number,title,state,createdAt,mergedAt,closedAt,labels,body,reviewDecision
 ```
 
@@ -36,16 +36,16 @@ For each PR, gather:
 - Phase reached (`copilot`, `claude`, `done`)
 - Whether it was merged, closed, or is still open
 - Time from creation to merge (if merged)
-- Whether `needs-human` label was applied
+- Whether `human/blocked` label was applied
 
 Also check for stale issues:
 
 ```bash
-gh issue list --repo rnwolfe/mine --label in-progress --state open \
+gh issue list --repo rnwolfe/mine --label agent/implementing --state open \
   --json number,title,createdAt,labels
 ```
 
-Cross-reference with open PRs — an `in-progress` issue with no corresponding open PR
+Cross-reference with open PRs — an `agent/implementing` issue with no corresponding open PR
 indicates a stale state that needs cleanup.
 
 ### 2. Analyze Pipeline Health
@@ -58,17 +58,17 @@ Compute and present:
 | Merged | N (%) |
 | Closed without merge | N (%) |
 | Still open | N (%) |
-| Needed human intervention | N (%) |
+| Needed human intervention (`human/blocked`) | N (%) |
 | Avg copilot iterations | N |
 | Avg time to merge | N hours |
 | Reached claude phase | N (%) |
-| Stale in-progress issues | N |
+| Stale `agent/implementing` issues | N |
 
 Flag any concerning patterns:
 - High failure rate (> 30% closed without merge)
 - Excessive copilot iterations (avg > 2)
 - PRs stuck in open state > 48 hours
-- Stale `in-progress` issues with no PR
+- Stale `agent/implementing` issues with no PR
 
 ### 3. Audit Code Quality (if not pipeline-only)
 
@@ -127,7 +127,7 @@ Structure the full report as:
 <ranked list of feedback categories>
 
 ### Stale State
-<in-progress issues without PRs>
+<agent/implementing issues without PRs>
 
 ### Recommendations
 <numbered list of concrete improvements>

--- a/.claude/skills/draft-issue/SKILL.md
+++ b/.claude/skills/draft-issue/SKILL.md
@@ -100,7 +100,7 @@ Always ask for explicit approval before running `gh issue create`.
 
 After creating the issue, provide the issue number and URL. Suggest next steps:
 - "Created issue #N. Want to refine it further with `/refine-issue N`?"
-- "This might be a good candidate for `agent-ready` if you want autodev to pick it up."
+- "This might be a good candidate for `backlog/ready` if you want autodev to pick it up."
 
 ## Guidelines
 
@@ -113,5 +113,5 @@ After creating the issue, provide the issue number and URL. Suggest next steps:
 - **Check for duplicates first.** Nobody wants to write an issue that already exists.
 - **Match the project voice.** Issue descriptions should be clear and technical but
   not dry. Match the tone of existing well-written issues.
-- **Suggest `agent-ready` when appropriate.** If the issue is well-defined and
+- **Suggest `backlog/ready` when appropriate.** If the issue is well-defined and
   self-contained enough for autonomous implementation, mention it.

--- a/.claude/skills/product/SKILL.md
+++ b/.claude/skills/product/SKILL.md
@@ -37,16 +37,16 @@ reasoning is more valuable than a spec for the wrong thing.
 
 Before any output, read all of the following. Do not skip any of these.
 
+Read these files (use the Read tool, not bash):
+- `docs/internal/VISION.md`
+- `docs/internal/STATUS.md`
+- `docs/internal/DECISIONS.md`
+- Every file in `docs/internal/specs/`
+- `CLAUDE.md`
+
+Then fetch live data via bash:
+
 ```bash
-# Core vision and status
-cat docs/internal/VISION.md
-cat docs/internal/STATUS.md
-cat docs/internal/DECISIONS.md
-
-# Existing specs
-ls docs/internal/specs/
-# Read each spec file
-
 # Current backlog
 gh issue list --repo rnwolfe/mine --state open --limit 100 \
   --json number,title,body,labels
@@ -54,12 +54,10 @@ gh issue list --repo rnwolfe/mine --state open --limit 100 \
 # Recent merged work (what's actually shipped)
 gh pr list --repo rnwolfe/mine --state merged --limit 20 \
   --json number,title,body,mergedAt,labels
-
-# Existing skills (the autonomous pipeline)
-ls .claude/skills/
 ```
 
-Also read `CLAUDE.md` for architecture patterns and design principles.
+Also list the existing skills directory (`ls .claude/skills/`) to understand
+the current autonomous pipeline.
 
 This context read is non-negotiable. You cannot form a coherent product view without
 understanding what's been decided, what's been built, and what's already in the queue.
@@ -355,7 +353,7 @@ and a one-sentence explanation.
 
 After scoring, output one of three recommendations:
 
-**READY** — Passes all dimensions. Add `agent-ready` label and it's good for `/autodev`.
+**READY** — Passes all dimensions. Add `backlog/ready` label and it's good for `/autodev`.
 
 **REFINE** — Passes vision/phase/principle but has spec quality gaps. List exactly what's
 missing. Suggest using `/refine-issue N` to improve the spec quality.

--- a/.claude/skills/refine-issue/SKILL.md
+++ b/.claude/skills/refine-issue/SKILL.md
@@ -18,12 +18,12 @@ Examples:
 - `/refine-issue 35` — refine issue #35
 - `/refine-issue 42` — refine issue #42
 
-If no number is provided, auto-pick from the `needs-refinement` backlog:
+If no number is provided, auto-pick from the `backlog/needs-refinement` backlog:
 
-1. Query open issues labeled `needs-refinement`:
+1. Query open issues labeled `backlog/needs-refinement`:
 
 ```bash
-gh issue list --state open --label "needs-refinement" --json number,title,createdAt --jq 'sort_by(.createdAt)'
+gh issue list --state open --label "backlog/needs-refinement" --json number,title,createdAt --jq 'sort_by(.createdAt)'
 ```
 
 2. If results exist, present a numbered list with titles and ages:
@@ -40,8 +40,8 @@ Pick a number, or press Enter for the oldest (#42):
 
 3. Let the user pick one, or default to the oldest.
 
-4. If no `needs-refinement` issues exist, suggest:
-   "No issues labeled `needs-refinement`. Run `/sweep-issues` first to identify
+4. If no `backlog/needs-refinement` issues exist, suggest:
+   "No issues labeled `backlog/needs-refinement`. Run `/sweep-issues` first to identify
    issues that need work."
 
 ## Process
@@ -120,7 +120,7 @@ After approval, update the issue:
 gh issue edit $ISSUE_NUMBER --body "<updated_body>"
 ```
 
-Also suggest any label changes if appropriate (e.g., adding `agent-ready` if the issue
+Also suggest any label changes if appropriate (e.g., adding `backlog/ready` if the issue
 is now well-defined enough for autonomous implementation).
 
 Always ask for explicit approval before running `gh issue edit`.

--- a/.claude/skills/shared/issue-quality-checklist.md
+++ b/.claude/skills/shared/issue-quality-checklist.md
@@ -81,4 +81,4 @@ When evaluating an issue, check each item:
 | `phase:3` | Advanced features (vault, grow, dash, plugins) |
 | `good-first-issue` | Clear scope, isolated domain, good for new contributors |
 | `spec` | Has a spec document in `docs/internal/specs/` |
-| `agent-ready` | Issue is well-defined enough for autonomous implementation |
+| `backlog/ready` | Issue is well-defined enough for autonomous implementation |

--- a/.claude/skills/sweep-issues/SKILL.md
+++ b/.claude/skills/sweep-issues/SKILL.md
@@ -49,8 +49,8 @@ gh issue list --state open --limit 100 --json number,title,labels,body
 
 If the user provided a label filter, add `--label "<filter>"` to narrow the set.
 
-After fetching, manually filter out issues that already have `needs-refinement` or
-`agent-ready` labels — these are already in the pipeline.
+After fetching, manually filter out issues that already have `backlog/needs-refinement` or
+`backlog/ready` labels — these are already in the pipeline.
 
 ### 3. Assess Each Issue
 
@@ -69,7 +69,7 @@ Count a score as: Present = 1, Weak = 0.5, Missing = 0. Total out of 10 (or the
 applicable subset for the issue type).
 
 Assign a verdict:
-- **Ready** (8+/10): Already meets the bar — suggest `agent-ready` label
+- **Ready** (8+/10): Already meets the bar — suggest `backlog/ready` label
 - **Needs refinement** (4-7.5/10): Has gaps worth filling
 - **Stub** (<4/10): Needs significant work
 
@@ -96,16 +96,16 @@ items so the user knows what gaps to fill.
 ### 5. Apply Labels (With Approval)
 
 Ask the user which actions to take:
-- Apply `needs-refinement` label to issues verdicted as "Needs refinement" or "Stub"
+- Apply `backlog/needs-refinement` label to issues verdicted as "Needs refinement" or "Stub"
 - Optionally post a comment on each labeled issue listing the specific gaps found
-- Suggest `agent-ready` for issues that already meet the bar
+- Suggest `backlog/ready` for issues that already meet the bar
 
 **Always ask for explicit approval before modifying any issues.**
 
 After approval, apply labels:
 
 ```bash
-gh issue edit $ISSUE_NUMBER --add-label "needs-refinement"
+gh issue edit $ISSUE_NUMBER --add-label "backlog/needs-refinement"
 ```
 
 If the user opted for gap comments:
@@ -120,9 +120,9 @@ Print a results summary:
 
 ```
 Sweep complete:
-  - 2 issues already meet the bar (suggested agent-ready)
-  - 6 issues labeled needs-refinement
-  - 4 stubs labeled needs-refinement
+  - 2 issues already meet the bar (suggested backlog/ready)
+  - 6 issues labeled backlog/needs-refinement
+  - 4 stubs labeled backlog/needs-refinement
 
 Next step: run /refine-issue to start improving the highest-priority issues.
 ```
@@ -136,7 +136,7 @@ Next step: run /refine-issue to start improving the highest-priority issues.
   sections that don't apply to their type.
 - **Be efficient.** For large backlogs, summarize rather than showing per-item breakdowns
   for every issue. Only show detailed gaps for issues the user is likely to act on.
-- **Suggest `agent-ready` generously.** If an issue is close to the bar and the gaps are
+- **Suggest `backlog/ready` generously.** If an issue is close to the bar and the gaps are
   minor (e.g., missing CLAUDE.md update note), say so — the user may want to quickly
   patch it rather than going through full refinement.
 - **Batch sensibly.** If there are 50+ issues, process them in batches and let the user

--- a/.github/workflows/autodev-audit.yml
+++ b/.github/workflows/autodev-audit.yml
@@ -48,25 +48,26 @@ jobs:
             Fetch the last ${{ inputs.limit || '10' }} autodev PRs:
 
             ```bash
-            gh pr list --repo ${{ github.repository }} --label autodev --state all \
+            gh pr list --repo ${{ github.repository }} --state all \
               --limit ${{ inputs.limit || '10' }} \
-              --json number,title,state,createdAt,mergedAt,closedAt,labels,body,reviewDecision
+              --json number,title,state,createdAt,mergedAt,closedAt,labels,body,reviewDecision \
+              --jq '[.[] | select(.labels | map(.name) | any(startswith("via/")))]'
             ```
 
             For each PR, extract:
             - Phase reached (from `<!-- autodev-state: ... -->` HTML comment in PR body)
             - Copilot iteration count
-            - Whether `needs-human` label was applied
+            - Whether `human/blocked` label was applied
             - Time from creation to merge (if merged)
 
             Also check for stale issues:
 
             ```bash
-            gh issue list --repo ${{ github.repository }} --label in-progress --state open \
+            gh issue list --repo ${{ github.repository }} --label "agent/implementing" --state open \
               --json number,title,createdAt,labels
             ```
 
-            Cross-reference with open PRs — an `in-progress` issue with no corresponding
+            Cross-reference with open PRs — an `agent/implementing` issue with no corresponding
             open autodev PR indicates stale state.
 
             ## Step 2: Compute Pipeline Metrics
@@ -162,7 +163,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --title "Autodev Pipeline Audit — $DATE" \
             --body "$BODY" \
-            --label "autodev-audit"
+            --label "report/pipeline-audit"
 
       - name: Handle agent failure
         if: steps.agent.outcome == 'failure'
@@ -174,4 +175,4 @@ jobs:
             --repo "${{ github.repository }}" \
             --title "Autodev Pipeline Audit — $DATE (failed)" \
             --body "The audit agent failed to complete. Check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details." \
-            --label "autodev-audit"
+            --label "report/pipeline-audit"

--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -169,8 +169,8 @@ jobs:
             --body "⚠️ Autodev agent failed during implementation. No changes were committed. This issue needs human attention. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           gh issue edit "${{ inputs.issue_number }}" \
             --repo "${{ github.repository }}" \
-            --add-label "needs-human" \
-            --remove-label "in-progress"
+            --add-label "human/blocked" \
+            --remove-label "agent/implementing"
 
       - name: Revert protected file changes
         if: steps.agent.outcome == 'success'
@@ -223,5 +223,5 @@ jobs:
 
           gh issue edit "${{ inputs.issue_number }}" \
             --repo "${{ github.repository }}" \
-            --add-label "needs-human" \
-            --remove-label "in-progress"
+            --add-label "human/blocked" \
+            --remove-label "agent/implementing"

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -43,8 +43,8 @@ jobs:
           if [ "${{ github.event_name }}" = "schedule" ]; then
             # Scheduled poll: find open autodev PRs not in "done" phase
             PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
-              --label "autodev" --state open --json number,body \
-              --jq '[.[] | select(.body | test("autodev-state") | not) // select(.body | test("\"phase\": \"done\"") | not)] | first | .number // empty')
+              --state open --json number,body,labels \
+              --jq '[.[] | select(.labels | map(.name) | any(startswith("via/"))) | select(.body | test("autodev-state") | not) // select(.body | test("\"phase\": \"done\"") | not)] | first | .number // empty')
             if [ -z "$PR_NUMBER" ]; then
               echo "No actionable autodev PRs found. Skipping."
               echo "action=skip" >> "$GITHUB_OUTPUT"
@@ -69,7 +69,7 @@ jobs:
 
           # Check if PR has autodev label
           HAS_AUTODEV=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" \
-            --json labels --jq '[.labels[].name] | any(. == "autodev")')
+            --json labels --jq '[.labels[].name] | any(startswith("via/"))')
           if [ "$HAS_AUTODEV" != "true" ]; then
             echo "PR #$PR_NUMBER is not an autodev PR. Skipping."
             echo "action=skip" >> "$GITHUB_OUTPUT"
@@ -323,7 +323,7 @@ jobs:
           echo "::error::See logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           gh pr edit "${{ steps.route.outputs.pr_number }}" \
             --repo "${{ github.repository }}" \
-            --add-label "needs-human"
+            --add-label "human/blocked"
           gh pr comment "${{ steps.route.outputs.pr_number }}" \
             --repo "${{ github.repository }}" \
             --body "⚠️ Autodev agent failed during copilot review fix (iteration $(( ${{ steps.route.outputs.copilot_iterations }} + 1 ))). No changes were committed. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
@@ -399,7 +399,8 @@ jobs:
           # Add label to trigger Claude Code Review
           gh pr edit "${{ steps.route.outputs.pr_number }}" \
             --repo "${{ github.repository }}" \
-            --add-label "claude-review-requested"
+            --add-label "agent/review-claude" \
+            --remove-label "agent/review-copilot"
 
       # ── Claude fix path ───────────────────────────────────────────
       - name: Reconcile branch (claude fix)
@@ -486,7 +487,7 @@ jobs:
           echo "::error::See logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           gh pr edit "${{ steps.route.outputs.pr_number }}" \
             --repo "${{ github.repository }}" \
-            --add-label "needs-human"
+            --add-label "human/blocked"
           gh pr comment "${{ steps.route.outputs.pr_number }}" \
             --repo "${{ github.repository }}" \
             --body "⚠️ Autodev agent failed during final Claude review fix. No changes were committed. This PR needs human attention. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
@@ -542,14 +543,15 @@ jobs:
             --repo "${{ github.repository }}" \
             --body "$UPDATED_BODY"
 
-          # Remove the claude-review-requested label
+          # Remove review label and add merge-ready label
           if ! gh pr edit "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
-            --remove-label "claude-review-requested"; then
-            echo "::warning::Failed to remove label 'claude-review-requested' from PR #$PR_NUMBER. The label may not exist or there may be permission/API issues."
+            --remove-label "agent/review-claude" \
+            --add-label "human/review-merge"; then
+            echo "::warning::Failed to update labels on PR #$PR_NUMBER. There may be permission/API issues."
           fi
 
           # Post completion comment
           gh pr comment "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
-            --body "Autodev review pipeline complete. Copilot and Claude reviews have been addressed. Ready for human merge."
+            --body "Autodev review pipeline complete. Copilot and Claude reviews have been addressed. Labeled \`human/review-merge\` — ready for human merge."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 on:
-  # Label trigger: autodev pipeline adds "claude-review-requested" label
+  # Label trigger: autodev pipeline adds "agent/review-claude" label
   pull_request:
     types: [labeled]
   # Comment trigger: anyone comments with "@claude" on a PR
@@ -11,11 +11,11 @@ on:
 jobs:
   claude-review:
     # Only run when:
-    # 1. "claude-review-requested" label is added (autodev pipeline)
+    # 1. "agent/review-claude" label is added (autodev pipeline)
     # 2. A PR comment explicitly requests Claude review via @claude mention
     if: |
       github.actor != 'vercel[bot]' && (
-        (github.event_name == 'pull_request' && github.event.label.name == 'claude-review-requested') ||
+        (github.event_name == 'pull_request' && github.event.label.name == 'agent/review-claude') ||
         (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude'))
       )
 

--- a/maestro/Backlog-Loop/1_PICK_ISSUE.md
+++ b/maestro/Backlog-Loop/1_PICK_ISSUE.md
@@ -10,19 +10,19 @@
 
 ## Objective
 
-Select the next `agent-ready` issue from the GitHub backlog, verify it was labeled by a trusted user, create a fresh git worktree for implementation, and output the issue details for downstream documents.
+Select the next `backlog/ready` issue from the GitHub backlog, verify it was labeled by a trusted user, create a fresh git worktree for implementation, and output the issue details for downstream documents.
 
 ## Tasks
 
-- [ ] **Check concurrency**: Run `gh pr list --repo rnwolfe/mine --label maestro --state open --json number --jq 'length'`. If the count is >= 3, write "BLOCKED: concurrency limit reached (3 maestro PRs open)" to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md` and mark this task complete without proceeding further.
+- [ ] **Check concurrency**: Run `gh pr list --repo rnwolfe/mine --label via/maestro --state open --json number --jq 'length'`. If the count is >= 3, write "BLOCKED: concurrency limit reached (3 via/maestro PRs open)" to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md` and mark this task complete without proceeding further.
 
-- [ ] **Find candidate issue**: Run `gh issue list --repo rnwolfe/mine --label agent-ready --state open --json number,title,labels --jq '[.[] | select(.labels | map(.name) | (index("in-progress") | not) and (index("maestro") | not))] | sort_by(.number) | first'`. This excludes issues already labeled `in-progress` or `maestro` (being worked by another instance). If no issues found, write "BLOCKED: no agent-ready issues available" to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md` and mark complete.
+- [ ] **Find candidate issue**: Run `gh issue list --repo rnwolfe/mine --label backlog/ready --state open --json number,title,labels --jq '[.[] | select(.labels | map(.name) | (index("agent/implementing") | not) and (index("via/maestro") | not))] | sort_by(.number) | first'`. This excludes issues already labeled `agent/implementing` or `via/maestro` (being worked by another instance). If no issues found, write "BLOCKED: no backlog/ready issues available" to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md` and mark complete.
 
-- [ ] **Verify trusted labeler**: Use `gh api repos/rnwolfe/mine/issues/ISSUE_NUMBER/timeline --paginate --jq '[.[] | select(.event == "labeled" and .label.name == "agent-ready")] | last | .actor.login // empty'` to check who applied the label. Only proceed if the labeler is `rnwolfe`. If the result is empty or the labeler is untrusted, write "BLOCKED: untrusted labeler" to the issue file and mark complete.
+- [ ] **Verify trusted labeler**: Use `gh api repos/rnwolfe/mine/issues/ISSUE_NUMBER/timeline --paginate --jq '[.[] | select(.event == "labeled" and .label.name == "backlog/ready")] | last | .actor.login // empty'` to check who applied the label. Only proceed if the labeler is `rnwolfe`. If the result is empty or the labeler is untrusted, write "BLOCKED: untrusted labeler" to the issue file and mark complete.
 
-- [ ] **Label issue**: Apply both `maestro` and `in-progress` labels to claim the issue:
+- [ ] **Label issue**: Apply both `via/maestro` and `agent/implementing` labels to claim the issue:
   ```
-  gh issue edit ISSUE_NUMBER --repo rnwolfe/mine --add-label maestro --add-label in-progress
+  gh issue edit ISSUE_NUMBER --repo rnwolfe/mine --add-label via/maestro --add-label agent/implementing
   ```
   This prevents other parallel instances from picking the same issue.
 

--- a/maestro/Backlog-Loop/4_OPEN_PR.md
+++ b/maestro/Backlog-Loop/4_OPEN_PR.md
@@ -70,7 +70,7 @@ Commit all changes in the worktree, push the branch, and create a detailed PR. T
   - [ ] Criterion — why it wasn't met (if any)
   ```
 
-  Add the `maestro` label: `--label maestro`
+  Add the `via/maestro` label: `--label via/maestro`
 
   Run the `gh pr create` command from the worktree directory so it picks up the correct branch.
 

--- a/maestro/Backlog-Loop/8_FINALIZE.md
+++ b/maestro/Backlog-Loop/8_FINALIZE.md
@@ -10,20 +10,20 @@
 
 ## Objective
 
-Mark the PR and issue as ready for human review by applying the `maestro/review-ready` label. Clean up the git worktree. This signals to the maintainer that autonomous work is complete and the PR is ready for final review and merge.
+Mark the PR and issue as ready for human review by applying the `human/review-merge` label. Clean up the git worktree. This signals to the maintainer that autonomous work is complete and the PR is ready for final review and merge.
 
 ## Tasks
 
 - [ ] **Read PR and issue details**: Read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md` and extract the issue number, PR number, and worktree path. If no PR section exists (issue was blocked), skip to the cleanup step.
 
-- [ ] **Label PR as review-ready**: Add the `maestro/review-ready` label to the PR:
+- [ ] **Label PR as review-ready**: Add the `human/review-merge` label to the PR:
   ```
-  gh pr edit PR_NUMBER --repo rnwolfe/mine --add-label "maestro/review-ready"
+  gh pr edit PR_NUMBER --repo rnwolfe/mine --add-label "human/review-merge"
   ```
 
-- [ ] **Label issue as review-ready**: Add the `maestro/review-ready` label to the issue:
+- [ ] **Label issue as review-ready**: Add the `human/review-merge` label to the issue:
   ```
-  gh issue edit ISSUE_NUMBER --repo rnwolfe/mine --add-label "maestro/review-ready"
+  gh issue edit ISSUE_NUMBER --repo rnwolfe/mine --add-label "human/review-merge"
   ```
 
 - [ ] **Remove worktree**: Clean up the git worktree used for this implementation:
@@ -40,18 +40,18 @@ Mark the PR and issue as ready for human review by applying the `maestro/review-
   ### Loop {{LOOP_NUMBER}} — Finalized
   - **Issue:** #ISSUE_NUMBER
   - **PR:** #PR_NUMBER
-  - **Status:** maestro/review-ready — awaiting human review
+  - **Status:** human/review-merge — awaiting human review
   - **Worktree:** cleaned up
   ```
 
 ## Guidelines
 
-- The `maestro/review-ready` label signals to the maintainer that:
+- The `human/review-merge` label signals to the maintainer that:
   1. Implementation is complete
   2. Copilot review feedback has been addressed
   3. Self-review loop passed
   4. Documentation is up to date
   5. Follow-up issues have been created
-- Do NOT remove the `in-progress` or `maestro` labels — the maintainer will remove those when merging
+- Do NOT remove the `agent/implementing` or `via/maestro` labels — the maintainer will remove those when merging
 - Always clean up worktrees to avoid disk space accumulation across loops
 - If the worktree remove fails (dirty state), force-remove it — the branch and commits are already pushed

--- a/maestro/Backlog-Loop/9_PROGRESS.md
+++ b/maestro/Backlog-Loop/9_PROGRESS.md
@@ -11,16 +11,16 @@
 ## Objective
 
 Determine whether to continue the loop or exit. This document controls the pipeline:
-- If more `agent-ready` issues exist and no blockers, reset documents 1-8 to trigger another loop.
+- If more `backlog/ready` issues exist and no blockers, reset documents 1-8 to trigger another loop.
 - If blocked or backlog is empty, leave documents 1-8 completed so the pipeline exits.
 
 ## Tasks
 
 - [ ] **Check for blockers**: Read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_ISSUE.md`. If the status contains "BLOCKED" (concurrency limit, no issues, untrusted labeler), do NOT reset any documents — the pipeline should exit. Append the blocker reason to `{{AUTORUN_FOLDER}}/BACKLOG_LOG_{{DATE}}.md` and mark this task complete.
 
-- [ ] **Check backlog**: Run `gh issue list --repo rnwolfe/mine --label agent-ready --state open --json number,labels --jq '[.[] | select(.labels | map(.name) | (index("in-progress") | not) and (index("maestro") | not))] | length'`. If the count is 0, do NOT reset documents — the backlog is empty. Append "Backlog empty — pipeline exiting" to the log and mark complete.
+- [ ] **Check backlog**: Run `gh issue list --repo rnwolfe/mine --label backlog/ready --state open --json number,labels --jq '[.[] | select(.labels | map(.name) | (index("agent/implementing") | not) and (index("via/maestro") | not))] | length'`. If the count is 0, do NOT reset documents — the backlog is empty. Append "Backlog empty — pipeline exiting" to the log and mark complete.
 
-- [ ] **Check concurrency**: Run `gh pr list --repo rnwolfe/mine --label maestro --state open --json number --jq 'length'`. If >= 3, do NOT reset — concurrency limit reached. Append "Concurrency limit (3 maestro PRs open) — pipeline pausing" to the log and mark complete.
+- [ ] **Check concurrency**: Run `gh pr list --repo rnwolfe/mine --label via/maestro --state open --json number --jq 'length'`. If >= 3, do NOT reset — concurrency limit reached. Append "Concurrency limit (3 via/maestro PRs open) — pipeline pausing" to the log and mark complete.
 
 - [ ] **Reset for next loop**: If none of the above blockers apply, reset all tasks in documents 1 through 8 by unchecking all checkboxes in:
   - `{{AUTORUN_FOLDER}}/1_PICK_ISSUE.md`
@@ -44,8 +44,8 @@ Determine whether to continue the loop or exit. This document controls the pipel
 
 The pipeline exits when ANY of these are true:
 1. Issue file contains "BLOCKED"
-2. No `agent-ready` issues remain (excluding those labeled `in-progress` or `maestro`)
-3. Concurrency limit reached (3 open maestro PRs)
+2. No `backlog/ready` issues remain (excluding those labeled `agent/implementing` or `via/maestro`)
+3. Concurrency limit reached (3 open `via/maestro` PRs)
 
 When exiting, leave documents 1-8 with their tasks checked. Auto Run will see no unchecked tasks and stop.
 
@@ -54,4 +54,4 @@ When exiting, leave documents 1-8 with their tasks checked. Auto Run will see no
 - This document has **Reset on Completion** enabled in the playbook config
 - Documents 1-8 do NOT have Reset on Completion — they only reset when this document explicitly unchecks their tasks
 - Always append to the log, never overwrite it
-- The concurrency check uses the `maestro` label, not `autodev` — this playbook's PRs are independent of the GitHub Actions autodev pipeline
+- The concurrency check uses the `via/maestro` label, not `via/autodev` or `via/actions` — this playbook's PRs are independent of the GitHub Actions autodev pipeline

--- a/maestro/Backlog-Loop/README.md
+++ b/maestro/Backlog-Loop/README.md
@@ -1,5 +1,8 @@
 # Backlog Loop Playbook
 
+> **Experimental**: Maestro is not a production implementation path. The two production
+> paths are `/autodev` (interactive CLI) and GitHub Actions (always-on pipeline).
+
 A looping Auto Run playbook that picks issues from the GitHub backlog, implements them in isolated worktrees, runs through automated and self-review cycles, updates documentation, and opens review-ready PRs — then repeats until the backlog is empty or the concurrency limit is reached.
 
 ## Requirements
@@ -13,15 +16,15 @@ A looping Auto Run playbook that picks issues from the GitHub backlog, implement
 This playbook automates the full issue-to-PR lifecycle, including code review and documentation. It uses git worktrees for isolation, enabling multiple instances to run in parallel without conflicts.
 
 Each loop runs 9 steps then re-checks for more work:
-1. **Picks** the next `agent-ready` issue (excludes `in-progress` and `maestro` labeled issues)
-2. **Labels** the issue with `maestro` + `in-progress` to claim it
+1. **Picks** the next `backlog/ready` issue (excludes `agent/implementing` and `via/maestro` labeled issues)
+2. **Labels** the issue with `via/maestro` + `agent/implementing` to claim it
 3. **Plans** the implementation approach in a fresh worktree
 4. **Implements** the feature with tests
 5. **Opens a PR** with a detailed description
 6. **Waits for Copilot review** and addresses any feedback
 7. **Self-reviews** with a fresh-context subagent, iterating until clean
 8. **Updates documentation** (Starlight site, internal docs) and creates follow-up issues
-9. **Finalizes** by labeling PR/issue `maestro/review-ready` and cleaning up the worktree
+9. **Finalizes** by labeling PR/issue `human/review-merge` and cleaning up the worktree
 
 After step 9, `9_PROGRESS.md` checks if more issues are available and resets steps 1–8 for the next loop iteration.
 
@@ -36,7 +39,7 @@ After step 9, `9_PROGRESS.md` checks if more issues are available and resets ste
 | `5_COPILOT_REVIEW.md` | Wait for Copilot review, address feedback | No |
 | `6_SELF_REVIEW.md` | Fresh-context code review loop (up to 3 iterations) | No |
 | `7_DOCS_FOLLOWUP.md` | Update docs, create follow-up issues | No |
-| `8_FINALIZE.md` | Label `maestro/review-ready`, remove worktree | No |
+| `8_FINALIZE.md` | Label `human/review-merge`, remove worktree | No |
 | `9_PROGRESS.md` | Check for more issues, reset 1-8 if available, exit if done | **Yes** |
 
 ## Recommended Setup
@@ -60,8 +63,8 @@ Documents:
 This playbook supports multiple instances running simultaneously:
 
 - **Worktree isolation**: Each issue gets its own git worktree at `{{AGENT_PATH}}-worktrees/issue-ISSUE_NUMBER`, so parallel instances don't conflict on disk
-- **Label-based claiming**: Issues are labeled `maestro` + `in-progress` immediately after selection, preventing other instances from picking the same issue
-- **Concurrency limit**: Maximum 3 open `maestro` PRs at once (configurable in `1_PICK_ISSUE.md` and `9_PROGRESS.md`)
+- **Label-based claiming**: Issues are labeled `via/maestro` + `agent/implementing` immediately after selection, preventing other instances from picking the same issue
+- **Concurrency limit**: Maximum 3 open `via/maestro` PRs at once (configurable in `1_PICK_ISSUE.md` and `9_PROGRESS.md`)
 - **Independent state**: Each loop iteration writes to `LOOP_{{LOOP_NUMBER}}_*` files, so parallel loops don't overwrite each other's state
 
 To run in parallel, start multiple Maestro Auto Run sessions with this playbook. Each will independently pick different issues and work in isolated worktrees.
@@ -79,17 +82,17 @@ Each loop creates:
 
 | Label | Applied to | When | Purpose |
 |-------|-----------|------|---------|
-| `agent-ready` | Issue | Before playbook runs | Signals issue is ready for autonomous work |
-| `maestro` | Issue | On pick (step 1) | Claims issue for this playbook |
-| `in-progress` | Issue | On pick (step 1) | Prevents re-selection by parallel instances |
-| `maestro` | PR | On creation (step 4) | Identifies maestro-created PRs |
-| `maestro/review-ready` | PR + Issue | On finalize (step 8) | Signals human review can begin |
+| `backlog/ready` | Issue | Before playbook runs | Signals issue is ready for autonomous work |
+| `via/maestro` | Issue | On pick (step 1) | Claims issue for this playbook |
+| `agent/implementing` | Issue | On pick (step 1) | Prevents re-selection by parallel instances |
+| `via/maestro` | PR | On creation (step 4) | Identifies maestro-created PRs |
+| `human/review-merge` | PR + Issue | On finalize (step 8) | Signals human review can begin |
 
 ## Safety
 
 - Only processes issues labeled by trusted users (checked via timeline API)
 - Protected files (CLAUDE.md, workflows, autodev scripts) are never modified
-- Max 3 open maestro PRs at a time (concurrency guard)
+- Max 3 open `via/maestro` PRs at a time (concurrency guard)
 - Each implementation runs `make test` and `make build` before committing
 - Worktrees are cleaned up after each loop to avoid disk accumulation
 - Self-review loop has a max of 3 iterations to prevent infinite cycles

--- a/maestro/Review-Fix/README.md
+++ b/maestro/Review-Fix/README.md
@@ -1,5 +1,8 @@
 # Review Fix Playbook
 
+> **Experimental**: Maestro is not a production implementation path. The two production
+> paths are `/autodev` (interactive CLI) and GitHub Actions (always-on pipeline).
+
 A looping Auto Run playbook that addresses PR review feedback, replies to comments, and iterates until reviews are clean.
 
 ## Requirements

--- a/scripts/autodev/config.sh
+++ b/scripts/autodev/config.sh
@@ -8,17 +8,25 @@
 AUTODEV_REPO="rnwolfe/mine"
 AUTODEV_BASE_BRANCH="main"
 
-# Labels
-AUTODEV_LABEL_READY="agent-ready"
-AUTODEV_LABEL_IN_PROGRESS="in-progress"
-AUTODEV_LABEL_AUTODEV="autodev"
-AUTODEV_LABEL_NEEDS_HUMAN="needs-human"
-AUTODEV_LABEL_CLAUDE_REVIEW="claude-review-requested"
+# Pipeline stage labels (mutually exclusive per issue/PR)
+AUTODEV_LABEL_READY="backlog/ready"
+AUTODEV_LABEL_IMPLEMENTING="agent/implementing"
+AUTODEV_LABEL_REVIEW_COPILOT="agent/review-copilot"
+AUTODEV_LABEL_REVIEW_CLAUDE="agent/review-claude"
+AUTODEV_LABEL_REVIEW_MERGE="human/review-merge"
+AUTODEV_LABEL_BLOCKED="human/blocked"
+
+# Origin labels (persistent, one per PR)
+AUTODEV_LABEL_VIA_ACTIONS="via/actions"
+AUTODEV_LABEL_VIA_AUTODEV="via/autodev"
+
+# Report labels
+AUTODEV_LABEL_PIPELINE_AUDIT="report/pipeline-audit"
 
 # Limits
 AUTODEV_MAX_ITERATIONS=3
 
-# Trusted users who can trigger autodev via agent-ready label
+# Trusted users who can trigger autodev via backlog/ready label
 # Only these users (repo owner/collaborators) can queue work for autonomous execution.
 AUTODEV_TRUSTED_USERS=("rnwolfe")
 

--- a/scripts/autodev/migrate-labels.sh
+++ b/scripts/autodev/migrate-labels.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# scripts/autodev/migrate-labels.sh — Migrate GitHub labels to new taxonomy
+#
+# Usage:
+#   scripts/autodev/migrate-labels.sh create    # Create all new labels (idempotent)
+#   scripts/autodev/migrate-labels.sh migrate   # Move issues/PRs from old → new labels
+#   scripts/autodev/migrate-labels.sh cleanup   # Delete old labels
+#
+# Run in order: create → migrate → cleanup
+
+source "$(dirname "$0")/config.sh"
+
+# ── Old → New label mapping ──────────────────────────────────────
+
+declare -A LABEL_MAP=(
+    ["agent-ready"]="backlog/ready"
+    ["needs-refinement"]="backlog/needs-refinement"
+    ["in-progress"]="agent/implementing"
+    ["claude-review-requested"]="agent/review-claude"
+    ["needs-human"]="human/blocked"
+    ["autodev"]="via/autodev"
+    ["maestro"]="via/maestro"
+    ["maestro/review-ready"]="human/review-merge"
+    ["autodev-audit"]="report/pipeline-audit"
+)
+
+# ── New labels with colors ────────────────────────────────────────
+
+declare -A NEW_LABELS=(
+    # backlog/* — light blue (#C5DEF5)
+    ["backlog/ready"]="#C5DEF5"
+    ["backlog/needs-refinement"]="#C5DEF5"
+    ["backlog/triage"]="#C5DEF5"
+    ["backlog/needs-spec"]="#C5DEF5"
+
+    # agent/* — salmon (#E99695)
+    ["agent/implementing"]="#E99695"
+    ["agent/review-copilot"]="#E99695"
+    ["agent/review-claude"]="#E99695"
+
+    # human/* — green (#0E8A16)
+    ["human/blocked"]="#0E8A16"
+    ["human/review-merge"]="#0E8A16"
+
+    # via/* — grey (#EDEDED)
+    ["via/autodev"]="#EDEDED"
+    ["via/actions"]="#EDEDED"
+    ["via/maestro"]="#EDEDED"
+
+    # report/* — purple (#D876E3)
+    ["report/pipeline-audit"]="#D876E3"
+)
+
+# ── Label descriptions ────────────────────────────────────────────
+
+declare -A LABEL_DESCRIPTIONS=(
+    ["backlog/ready"]="Issue is ready for autonomous implementation"
+    ["backlog/needs-refinement"]="Issue needs further refinement before implementation"
+    ["backlog/triage"]="New issue, needs evaluation"
+    ["backlog/needs-spec"]="Passed eval, needs specification"
+    ["agent/implementing"]="Agent is actively implementing this issue"
+    ["agent/review-copilot"]="Agent addressing Copilot feedback"
+    ["agent/review-claude"]="Agent addressing Claude review feedback"
+    ["human/blocked"]="Automation hit a limit, needs human intervention"
+    ["human/review-merge"]="All automated reviews done, needs human merge"
+    ["via/autodev"]="Created by /autodev CLI skill"
+    ["via/actions"]="Created by GitHub Actions pipeline"
+    ["via/maestro"]="Created by maestro orchestration"
+    ["report/pipeline-audit"]="Weekly pipeline health report"
+)
+
+# ── Subcommands ───────────────────────────────────────────────────
+
+cmd_create() {
+    autodev_info "Creating new labels (idempotent via --force)..."
+
+    for label in "${!NEW_LABELS[@]}"; do
+        local color="${NEW_LABELS[$label]}"
+        local desc="${LABEL_DESCRIPTIONS[$label]:-}"
+        autodev_info "  Creating label: $label ($color)"
+        gh label create "$label" \
+            --repo "$AUTODEV_REPO" \
+            --color "${color#\#}" \
+            --description "$desc" \
+            --force
+    done
+
+    autodev_info "All labels created."
+}
+
+cmd_migrate() {
+    autodev_info "Migrating issues/PRs from old labels to new labels..."
+
+    for old_label in "${!LABEL_MAP[@]}"; do
+        local new_label="${LABEL_MAP[$old_label]}"
+        autodev_info "  Migrating: $old_label → $new_label"
+
+        # Find open issues with the old label
+        local issues
+        issues=$(gh issue list \
+            --repo "$AUTODEV_REPO" \
+            --label "$old_label" \
+            --state all \
+            --json number \
+            --jq '.[].number' 2>/dev/null) || true
+
+        for issue in $issues; do
+            autodev_info "    Issue #$issue: adding '$new_label', removing '$old_label'"
+            gh issue edit "$issue" \
+                --repo "$AUTODEV_REPO" \
+                --add-label "$new_label" \
+                --remove-label "$old_label" || true
+        done
+
+        # Find PRs with the old label
+        local prs
+        prs=$(gh pr list \
+            --repo "$AUTODEV_REPO" \
+            --label "$old_label" \
+            --state all \
+            --json number \
+            --jq '.[].number' 2>/dev/null) || true
+
+        for pr in $prs; do
+            autodev_info "    PR #$pr: adding '$new_label', removing '$old_label'"
+            gh pr edit "$pr" \
+                --repo "$AUTODEV_REPO" \
+                --add-label "$new_label" \
+                --remove-label "$old_label" || true
+        done
+    done
+
+    autodev_info "Migration complete."
+}
+
+cmd_cleanup() {
+    autodev_info "Deleting old labels..."
+
+    for old_label in "${!LABEL_MAP[@]}"; do
+        autodev_info "  Deleting: $old_label"
+        gh label delete "$old_label" \
+            --repo "$AUTODEV_REPO" \
+            --yes 2>/dev/null || autodev_warn "  Label '$old_label' not found (already deleted?)"
+    done
+
+    autodev_info "Cleanup complete."
+}
+
+# ── Main ──────────────────────────────────────────────────────────
+
+case "${1:-}" in
+    create)  cmd_create  ;;
+    migrate) cmd_migrate ;;
+    cleanup) cmd_cleanup ;;
+    *)
+        echo "Usage: $(basename "$0") {create|migrate|cleanup}" >&2
+        echo "" >&2
+        echo "  create   Create all new labels (idempotent)" >&2
+        echo "  migrate  Move issues/PRs from old → new labels" >&2
+        echo "  cleanup  Delete old labels" >&2
+        exit 1
+        ;;
+esac

--- a/scripts/autodev/open-pr.sh
+++ b/scripts/autodev/open-pr.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # scripts/autodev/open-pr.sh — Create a PR for an autodev implementation
 #
 # Usage:
-#   scripts/autodev/open-pr.sh ISSUE_NUMBER BRANCH_NAME
+#   scripts/autodev/open-pr.sh ISSUE_NUMBER BRANCH_NAME [ORIGIN_LABEL]
 #
 # Uses agent-generated PR description from /tmp/pr-description.md if available,
 # otherwise falls back to a basic template.
@@ -14,6 +14,7 @@ source "$(dirname "$0")/config.sh"
 
 ISSUE_NUMBER="${1:?Usage: open-pr.sh ISSUE_NUMBER BRANCH_NAME}"
 BRANCH_NAME="${2:?Usage: open-pr.sh ISSUE_NUMBER BRANCH_NAME}"
+ORIGIN_LABEL="${3:-$AUTODEV_LABEL_VIA_ACTIONS}"
 
 # ── Read issue ─────────────────────────────────────────────────────
 
@@ -70,7 +71,7 @@ PR_URL=$(gh pr create \
     --base "$AUTODEV_BASE_BRANCH" \
     --title "$PR_TITLE" \
     --body "$PR_BODY" \
-    --label "$AUTODEV_LABEL_AUTODEV")
+    --label "$ORIGIN_LABEL" --label "$AUTODEV_LABEL_REVIEW_COPILOT")
 
 autodev_info "Created PR: $PR_URL"
 


### PR DESCRIPTION
## Summary

- Adds `/product` — a strategic product ownership skill that enforces vision coherence before anything reaches the backlog. Acts as a product owner, not a feature generator: runs a four-part vision filter (identity, principle, phase, replacement tests), writes spec docs to `docs/internal/specs/`, can run roadmap health checks, evaluate individual issues (READY / REFINE / DECLINE), and sync the living docs.
- Adds `/autodev` — the CLI counterpart to the GitHub Actions pipeline. Pick an `agent-ready` issue, fresh worktree off `origin/main`, implement, `make test` + `make build`, open PR with acceptance criteria verified.
- Adds `docs/internal/LIFECYCLE.md` — authoritative map of the full product development lifecycle: 7 phases, 3 implementation paths, review pipeline, audit layer, and a Mermaid flowchart.
- Updates `CLAUDE.md` to reference the lifecycle doc and document both new skills.

## Changes

- **New files**:
  - `.claude/skills/product/SKILL.md` — strategic roadmap ownership skill
  - `.claude/skills/autodev/SKILL.md` — autonomous implementation skill
  - `docs/internal/LIFECYCLE.md` — full lifecycle map with Mermaid diagram

- **Modified files**:
  - `CLAUDE.md` — documents both skills, lifecycle section, updated pipeline flow description

## Lifecycle Overview

7 phases, all mapped to concrete skills/tools:

| Phase | Name | Primary tools |
|-------|------|---------------|
| 1 | Roadmap | `/product`, `/product sync` |
| 2 | Feature Definition | `/product spec`, `/brainstorm`, `/draft-issue` |
| 3 | Backlog Quality | `/sweep-issues`, `/refine-issue`, `/product eval N` → **gate: `agent-ready`** |
| 4 | Implementation | **Path A**: Maestro Auto Run · **Path B**: `/autodev` · **Path C**: GH Actions |
| 5 | Review | Copilot iterations → Claude review → done |
| 6 | Merge | Human (target: automated) |
| 7 | Feedback | `/product sync` → back to Phase 1 |

Audit layer (cross-cutting): `/sweep-issues`, `/autodev-audit`, `/personality-audit`

## Acceptance Criteria

- [x] `/product` skill enforces vision filter before any spec is written
- [x] `/product` can run health checks, eval issues, draft specs, and sync living docs
- [x] `/autodev` skill documented and committed (was previously untracked)
- [x] `LIFECYCLE.md` covers all 7 phases, all 3 implementation paths, review loop, audit layer
- [x] Mermaid diagram renders correctly (LR flowchart, validated via Mermaid MCP)
- [x] `CLAUDE.md` references lifecycle doc as authoritative source