### PR TITLE
docs: add testing, error message, and quality gate standards for autodev

### DIFF
--- a/.claude/skills/autodev/SKILL.md
+++ b/.claude/skills/autodev/SKILL.md
@@ -156,6 +156,32 @@ For example, before implementing a new `mine tmux` subcommand, read:
 
 ---
 
+## Step 5.5 — Pre-Commit Quality Review
+
+Before running `make test`, review your implementation against these checks:
+
+**Reference implementation**: If the issue cites a reference file (e.g. "follow the
+pattern in `cmd/config.go:174`"), verify you read it and matched its patterns. Check:
+editor invocation, error message style, stdin/stdout/stderr wiring, temp file cleanup.
+
+**Testing quality**:
+- Integration tests exercise the actual `runXxx` handler, not just internal helpers
+- External tools (editors, shells) are mocked with fake scripts in `t.TempDir()`
+- Error paths are tested end-to-end (handler → error), not just at the helper level
+- If the issue says "integration test for X", the test must call the handler function
+
+**Error messages**:
+- Command suggestions use `ui.Accent.Render()` (see `cmd/config.go:180`)
+- Invalid input errors include the expected format/pattern
+- Errors are wrapped with operation context (`"saving profile: %w"`)
+
+**Documentation completeness**:
+- CLAUDE.md key files table updated if new files were added
+- CLAUDE.md architecture pattern updated if CLI surface changed
+- Site docs updated with new commands, flags, and error table entries
+
+---
+
 ## Step 6 — Verify
 
 From the worktree directory, run:

--- a/.claude/skills/shared/issue-quality-checklist.md
+++ b/.claude/skills/shared/issue-quality-checklist.md
@@ -42,7 +42,9 @@ How this connects to existing mine features:
 - [ ] Specific, testable criterion that maps to one verifiable behavior
 - [ ] Another criterion — include happy path AND edge cases
 - [ ] Error handling: what happens when X fails?
-- [ ] Test requirements: unit tests for domain logic, integration tests if needed
+- [ ] Unit tests for domain helpers in `internal/<pkg>/`
+- [ ] Integration tests in `cmd/` that exercise the `runXxx` handler end-to-end (not just helpers)
+- [ ] External tool interactions tested via fake scripts in `t.TempDir()` (if applicable)
 - [ ] Performance: command completes within the <50ms budget (if applicable)
 
 > Each checkbox should be independently verifiable. Avoid vague criteria like

--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -99,6 +99,13 @@ jobs:
               - Command reference: site/src/content/docs/commands/<command>.md
               - Follow existing pages for format (YAML frontmatter, then markdown)
             - Write tests for new functionality
+            - QUALITY GATE — Before committing, verify:
+              - If the issue references a file pattern to follow, you have read it and matched it
+              - Integration tests call the actual runXxx handler, not just helper functions
+              - External tool tests use fake scripts in t.TempDir() (see cmd/tmux_test.go:59)
+              - Error messages use ui.Accent.Render() for command suggestions (see cmd/config.go:180)
+              - Invalid input errors include the expected format
+              - All CLAUDE.md references in acceptance criteria are actually updated
             - Keep files under 500 lines
 
             ## Issue #${{ inputs.issue_number }}: ${{ steps.prep.outputs.title }}


### PR DESCRIPTION
## Summary

Codify the patterns that distinguish high-quality agent output (like PR #164) from lower-quality output (like PR #163) as explicit project standards. Both PRs implemented `mine env edit` from the same issue (#122), same model, same instructions — yet #164 was meaningfully better. The quality gap came from ambiguity in the instructions: acceptance criteria told the agent WHAT to build, but CLAUDE.md and the agent prompt didn't sufficiently constrain HOW.

This PR reduces interpretation surface by documenting the patterns that #164 got right (and #163 missed) as written standards across four files.

## Changes

- **CLAUDE.md**: Added "Testing Standards" section (unit vs integration test definitions, external binary mocking, test isolation, error path testing, test naming) and "Error Message Standards" section (accent rendering, expected format inclusion, error wrapping, user-facing error structure)
- **`.claude/skills/autodev/SKILL.md`**: Added "Step 5.5 — Pre-Commit Quality Review" between Implement and Verify steps — covers reference implementation verification, testing quality, error messages, and documentation completeness
- **`.github/workflows/autodev-implement.yml`**: Added QUALITY GATE checklist (6 bullets) to the CI agent prompt, mirroring the skill's checks so both local and CI agents get identical guidance
- **`.claude/skills/shared/issue-quality-checklist.md`**: Replaced vague "Test requirements: unit tests for domain logic, integration tests if needed" with three specific checkboxes: unit tests for domain helpers, integration tests exercising `runXxx` handlers, and external tool fake-script testing

## Test plan

- [x] `make build` passes
- [x] `make test` passes (all tests green)
- [x] No code changes — documentation/config only, so no new tests needed
- [ ] Verify that future autodev runs produce more consistent output quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)