### PR TITLE
feat: add mine tmux window — manage windows within a session

### DIFF
--- a/cmd/tmux_window.go
+++ b/cmd/tmux_window.go
@@ -1,0 +1,335 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/rnwolfe/mine/internal/hook"
+	"github.com/rnwolfe/mine/internal/tmux"
+	"github.com/rnwolfe/mine/internal/tui"
+	"github.com/rnwolfe/mine/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var tmuxWindowSession string
+
+// Injectable for testing.
+var (
+	listWindowsFunc   = tmux.ListWindows
+	newWindowFunc     = tmux.NewWindow
+	killWindowFunc    = tmux.KillWindow
+	renameWindowFunc  = tmux.RenameWindow
+	currentSessionFunc = tmux.CurrentSession
+)
+
+func init() {
+	tmuxCmd.AddCommand(tmuxWindowCmd)
+	tmuxWindowCmd.AddCommand(tmuxWindowLsCmd)
+	tmuxWindowCmd.AddCommand(tmuxWindowNewCmd)
+	tmuxWindowCmd.AddCommand(tmuxWindowKillCmd)
+	tmuxWindowCmd.AddCommand(tmuxWindowRenameCmd)
+
+	// --session flag is inherited by all window subcommands.
+	tmuxWindowCmd.PersistentFlags().StringVar(&tmuxWindowSession, "session", "", "Target session (defaults to current)")
+}
+
+// resolveWindowSession returns the session name from the --session flag or
+// the current tmux session. Errors if neither is available.
+func resolveWindowSession(flag string) (string, error) {
+	if flag != "" {
+		return flag, nil
+	}
+	if !tmux.InsideTmux() {
+		return "", fmt.Errorf("not inside a tmux session — use %s to target a specific session",
+			ui.Accent.Render("--session <name>"))
+	}
+	return currentSessionFunc()
+}
+
+// --- mine tmux window ---
+
+var tmuxWindowCmd = &cobra.Command{
+	Use:   "window",
+	Short: "Manage windows within a tmux session",
+	Long:  `List, create, kill, and rename windows in a tmux session.`,
+	RunE:  hook.Wrap("tmux.window", runTmuxWindowHelp),
+}
+
+func runTmuxWindowHelp(_ *cobra.Command, _ []string) error {
+	fmt.Println()
+	fmt.Println(ui.Title.Render("  Tmux Windows"))
+	fmt.Println()
+	fmt.Printf("  %s  %s\n", ui.Accent.Render("mine tmux window ls"), ui.Muted.Render("List windows in current session"))
+	fmt.Printf("  %s  %s\n", ui.Accent.Render("mine tmux window new <name>"), ui.Muted.Render("Create a new window"))
+	fmt.Printf("  %s  %s\n", ui.Accent.Render("mine tmux window kill [name]"), ui.Muted.Render("Kill a window"))
+	fmt.Printf("  %s  %s\n", ui.Accent.Render("mine tmux window rename [old] [new]"), ui.Muted.Render("Rename a window"))
+	fmt.Println()
+	return nil
+}
+
+// --- mine tmux window ls ---
+
+var tmuxWindowLsCmd = &cobra.Command{
+	Use:     "ls",
+	Aliases: []string{"list"},
+	Short:   "List windows in the current session",
+	RunE:    hook.Wrap("tmux.window.ls", runTmuxWindowLs),
+}
+
+func runTmuxWindowLs(_ *cobra.Command, _ []string) error {
+	if !tmux.Available() {
+		return fmt.Errorf("tmux not found in PATH — install tmux first")
+	}
+
+	session, err := resolveWindowSession(tmuxWindowSession)
+	if err != nil {
+		return err
+	}
+
+	windows, err := listWindowsFunc(session)
+	if err != nil {
+		return err
+	}
+
+	return printWindowList(session, windows)
+}
+
+// --- mine tmux window new ---
+
+var tmuxWindowNewCmd = &cobra.Command{
+	Use:   "new <name>",
+	Short: "Create a new window in the current session",
+	Args:  cobra.ExactArgs(1),
+	RunE:  hook.Wrap("tmux.window.new", runTmuxWindowNew),
+}
+
+func runTmuxWindowNew(_ *cobra.Command, args []string) error {
+	if !tmux.Available() {
+		return fmt.Errorf("tmux not found in PATH — install tmux first")
+	}
+
+	session, err := resolveWindowSession(tmuxWindowSession)
+	if err != nil {
+		return err
+	}
+
+	name := args[0]
+	if err := newWindowFunc(session, name); err != nil {
+		return err
+	}
+
+	ui.Ok(fmt.Sprintf("Window %s created in session %s",
+		ui.Accent.Render(name), ui.Accent.Render(session)))
+	fmt.Println()
+	return nil
+}
+
+// --- mine tmux window kill ---
+
+var tmuxWindowKillCmd = &cobra.Command{
+	Use:   "kill [name]",
+	Short: "Kill a window in the current session",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  hook.Wrap("tmux.window.kill", runTmuxWindowKill),
+}
+
+func runTmuxWindowKill(_ *cobra.Command, args []string) error {
+	if !tmux.Available() {
+		return fmt.Errorf("tmux not found in PATH — install tmux first")
+	}
+
+	session, err := resolveWindowSession(tmuxWindowSession)
+	if err != nil {
+		return err
+	}
+
+	windows, err := listWindowsFunc(session)
+	if err != nil {
+		return err
+	}
+
+	if len(windows) == 0 {
+		return fmt.Errorf("no windows in session %q", session)
+	}
+
+	var target *tmux.Window
+
+	if len(args) > 0 {
+		name := args[0]
+		w := tmux.FindWindowByName(name, windows)
+		if w == nil {
+			return fmt.Errorf("no window named %q in session %q", name, session)
+		}
+		target = w
+	} else {
+		if !tui.IsTTY() {
+			fmt.Println()
+			fmt.Println(ui.Muted.Render("  Specify a window name or run interactively in a terminal."))
+			return printWindowList(session, windows)
+		}
+
+		items := make([]tui.Item, len(windows))
+		for i := range windows {
+			items[i] = windows[i]
+		}
+
+		chosen, err := tui.Run(items,
+			tui.WithTitle(ui.IconPick+"Kill window"),
+			tui.WithHeight(12),
+		)
+		if err != nil {
+			return err
+		}
+		if chosen == nil {
+			return nil // user canceled
+		}
+
+		for i := range windows {
+			if windows[i].Name == chosen.Title() {
+				target = &windows[i]
+				break
+			}
+		}
+	}
+
+	if err := killWindowFunc(session, target.Name); err != nil {
+		return err
+	}
+
+	ui.Ok(fmt.Sprintf("Killed window %s in session %s",
+		ui.Accent.Render(target.Name), ui.Accent.Render(session)))
+	fmt.Println()
+	return nil
+}
+
+// --- mine tmux window rename ---
+
+var tmuxWindowRenameCmd = &cobra.Command{
+	Use:   "rename [old] [new]",
+	Short: "Rename a window in the current session",
+	Long: `Rename a window interactively or directly.
+
+  2 args: rename directly without prompts
+  1 arg:  select window by name, then prompt for new name
+  0 args: open TUI picker to select window, then prompt for new name`,
+	Args: cobra.MaximumNArgs(2),
+	RunE: hook.Wrap("tmux.window.rename", runTmuxWindowRename),
+}
+
+func runTmuxWindowRename(_ *cobra.Command, args []string) error {
+	if !tmux.Available() {
+		return fmt.Errorf("tmux not found in PATH — install tmux first")
+	}
+
+	session, err := resolveWindowSession(tmuxWindowSession)
+	if err != nil {
+		return err
+	}
+
+	// 2 args: direct rename, no prompts.
+	if len(args) == 2 {
+		oldName, newName := args[0], args[1]
+		if newName == "" {
+			return fmt.Errorf("new window name cannot be empty")
+		}
+		if err := renameWindowFunc(session, oldName, newName); err != nil {
+			return err
+		}
+		ui.Ok(fmt.Sprintf("Renamed window %s → %s in session %s",
+			ui.Accent.Render(oldName), ui.Accent.Render(newName), ui.Accent.Render(session)))
+		fmt.Println()
+		return nil
+	}
+
+	windows, err := listWindowsFunc(session)
+	if err != nil {
+		return err
+	}
+
+	if len(windows) == 0 {
+		return fmt.Errorf("no windows in session %q", session)
+	}
+
+	var oldName string
+
+	if len(args) == 1 {
+		name := args[0]
+		w := tmux.FindWindowByName(name, windows)
+		if w == nil {
+			return fmt.Errorf("no window named %q in session %q", name, session)
+		}
+		oldName = w.Name
+	} else {
+		// 0 args: use TUI picker if TTY, else list and return.
+		if !tui.IsTTY() {
+			fmt.Println()
+			fmt.Println(ui.Muted.Render("  Specify a window name or run interactively in a terminal."))
+			return printWindowList(session, windows)
+		}
+
+		items := make([]tui.Item, len(windows))
+		for i := range windows {
+			items[i] = windows[i]
+		}
+
+		chosen, err := tui.Run(items,
+			tui.WithTitle(ui.IconPick+"Rename window"),
+			tui.WithHeight(12),
+		)
+		if err != nil {
+			return err
+		}
+		if chosen == nil {
+			return nil // user canceled
+		}
+		oldName = chosen.Title()
+	}
+
+	// Prompt for new name.
+	fmt.Fprintf(os.Stderr, "  New name for %s: ", ui.Accent.Render(oldName))
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	newName := strings.TrimSpace(line)
+
+	if newName == "" {
+		return fmt.Errorf("new window name cannot be empty")
+	}
+
+	if err := renameWindowFunc(session, oldName, newName); err != nil {
+		return err
+	}
+
+	ui.Ok(fmt.Sprintf("Renamed window %s → %s in session %s",
+		ui.Accent.Render(oldName), ui.Accent.Render(newName), ui.Accent.Render(session)))
+	fmt.Println()
+	return nil
+}
+
+// --- helpers ---
+
+func printWindowList(session string, windows []tmux.Window) error {
+	if len(windows) == 0 {
+		fmt.Println()
+		fmt.Printf("  %s\n", ui.Muted.Render("No windows in session "+session+"."))
+		fmt.Printf("  Create one: %s\n", ui.Accent.Render("mine tmux window new <name>"))
+		fmt.Println()
+		return nil
+	}
+
+	fmt.Println()
+	for _, w := range windows {
+		marker := " "
+		if w.Active {
+			marker = ui.Success.Render("*")
+		}
+		fmt.Printf("  %s %-20s %s\n",
+			marker,
+			ui.Accent.Render(w.Name),
+			ui.Muted.Render(fmt.Sprintf("index %d", w.Index)),
+		)
+	}
+	fmt.Println()
+	return nil
+}

--- a/cmd/tmux_window_test.go
+++ b/cmd/tmux_window_test.go
@@ -1,0 +1,405 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rnwolfe/mine/internal/tmux"
+)
+
+// setupWindowFuncs replaces all injectable window functions with stubs and
+// returns a cleanup function that restores the originals.
+func setupWindowFuncs(t *testing.T, windows []tmux.Window, session string) {
+	t.Helper()
+
+	origList := listWindowsFunc
+	origNew := newWindowFunc
+	origKill := killWindowFunc
+	origRename := renameWindowFunc
+	origCurrent := currentSessionFunc
+
+	t.Cleanup(func() {
+		listWindowsFunc = origList
+		newWindowFunc = origNew
+		killWindowFunc = origKill
+		renameWindowFunc = origRename
+		currentSessionFunc = origCurrent
+		tmuxWindowSession = ""
+	})
+
+	listWindowsFunc = func(_ string) ([]tmux.Window, error) { return windows, nil }
+	newWindowFunc = func(_, _ string) error { return nil }
+	killWindowFunc = func(_, _ string) error { return nil }
+	renameWindowFunc = func(_, _, _ string) error { return nil }
+	currentSessionFunc = func() (string, error) { return session, nil }
+}
+
+// --- mine tmux window ls ---
+
+// TestRunTmuxWindowLs_NotInsideTmux verifies that ls errors when not inside
+// tmux and no --session flag is given.
+func TestRunTmuxWindowLs_NotInsideTmux(t *testing.T) {
+	setupTmuxEnv(t)
+	// Clear TMUX so InsideTmux() returns false.
+	t.Setenv("TMUX", "")
+	tmuxWindowSession = ""
+	defer func() { tmuxWindowSession = "" }()
+
+	err := runTmuxWindowLs(nil, []string{})
+	if err == nil {
+		t.Fatal("expected error when not inside tmux and no --session given")
+	}
+	if !strings.Contains(err.Error(), "not inside a tmux session") {
+		t.Errorf("expected 'not inside a tmux session' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--session") {
+		t.Errorf("expected '--session' hint in error, got: %v", err)
+	}
+}
+
+// TestRunTmuxWindowLs_NoWindows verifies that when a session has no windows,
+// the command prints guidance and returns nil.
+func TestRunTmuxWindowLs_NoWindows(t *testing.T) {
+	setupTmuxEnv(t)
+	setupWindowFuncs(t, []tmux.Window{}, "mysession")
+	t.Setenv("TMUX", "/tmp/tmux-test,12345,0")
+
+	err := runTmuxWindowLs(nil, []string{})
+	if err != nil {
+		t.Errorf("expected nil error for empty window list, got: %v", err)
+	}
+}
+
+// TestRunTmuxWindowLs_WithSession verifies that --session flag uses the given
+// session name directly without calling currentSessionFunc.
+func TestRunTmuxWindowLs_WithSession(t *testing.T) {
+	setupTmuxEnv(t)
+	t.Setenv("TMUX", "")
+
+	windows := []tmux.Window{
+		{Index: 0, Name: "editor", Active: true},
+		{Index: 1, Name: "server", Active: false},
+	}
+
+	var capturedSession string
+	origList := listWindowsFunc
+	defer func() {
+		listWindowsFunc = origList
+		tmuxWindowSession = ""
+	}()
+	listWindowsFunc = func(s string) ([]tmux.Window, error) {
+		capturedSession = s
+		return windows, nil
+	}
+
+	tmuxWindowSession = "target-session"
+	output := captureStdout(t, func() {
+		_ = runTmuxWindowLs(nil, []string{})
+	})
+
+	if capturedSession != "target-session" {
+		t.Errorf("expected session 'target-session', got %q", capturedSession)
+	}
+	if !strings.Contains(output, "editor") {
+		t.Errorf("expected 'editor' in output, got: %s", output)
+	}
+	if !strings.Contains(output, "server") {
+		t.Errorf("expected 'server' in output, got: %s", output)
+	}
+}
+
+// TestRunTmuxWindowLs_ListWindows verifies that window list output includes
+// window names, indices, and an active marker.
+func TestRunTmuxWindowLs_ListWindows(t *testing.T) {
+	setupTmuxEnv(t)
+	windows := []tmux.Window{
+		{Index: 0, Name: "editor", Active: true},
+		{Index: 1, Name: "server", Active: false},
+	}
+	setupWindowFuncs(t, windows, "dev")
+	t.Setenv("TMUX", "/tmp/tmux-test,12345,0")
+
+	output := captureStdout(t, func() {
+		_ = runTmuxWindowLs(nil, []string{})
+	})
+
+	for _, want := range []string{"editor", "server", "index 0", "index 1"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q\nGot:\n%s", want, output)
+		}
+	}
+}
+
+// --- mine tmux window new ---
+
+// TestRunTmuxWindowNew_CreatesWindow verifies the happy path: window is created
+// and a success message is printed.
+func TestRunTmuxWindowNew_CreatesWindow(t *testing.T) {
+	setupTmuxEnv(t)
+	setupWindowFuncs(t, nil, "dev")
+	t.Setenv("TMUX", "/tmp/tmux-test,12345,0")
+
+	var capturedSession, capturedName string
+	origNew := newWindowFunc
+	defer func() { newWindowFunc = origNew }()
+	newWindowFunc = func(sess, name string) error {
+		capturedSession = sess
+		capturedName = name
+		return nil
+	}
+
+	output := captureStdout(t, func() {
+		_ = runTmuxWindowNew(nil, []string{"mywindow"})
+	})
+
+	if capturedName != "mywindow" {
+		t.Errorf("expected window name 'mywindow', got %q", capturedName)
+	}
+	if capturedSession != "dev" {
+		t.Errorf("expected session 'dev', got %q", capturedSession)
+	}
+	if !strings.Contains(output, "mywindow") {
+		t.Errorf("expected 'mywindow' in output, got: %s", output)
+	}
+}
+
+// TestRunTmuxWindowNew_ErrorPropagated verifies that a domain-layer error is
+// returned to the caller.
+func TestRunTmuxWindowNew_ErrorPropagated(t *testing.T) {
+	setupTmuxEnv(t)
+	setupWindowFuncs(t, nil, "dev")
+	t.Setenv("TMUX", "/tmp/tmux-test,12345,0")
+
+	newWindowFunc = func(_, _ string) error {
+		return fmt.Errorf("tmux: session not found")
+	}
+
+	err := runTmuxWindowNew(nil, []string{"mywindow"})
+	if err == nil {
+		t.Fatal("expected error from failing newWindowFunc, got nil")
+	}
+}
+
+// --- mine tmux window kill ---
+
+// TestRunTmuxWindowKill_ByName verifies that kill with a name arg kills directly.
+func TestRunTmuxWindowKill_ByName(t *testing.T) {
+	setupTmuxEnv(t)
+	windows := []tmux.Window{
+		{Index: 0, Name: "editor", Active: false},
+		{Index: 1, Name: "server", Active: true},
+	}
+	setupWindowFuncs(t, windows, "dev")
+	t.Setenv("TMUX", "/tmp/tmux-test,12345,0")
+
+	var killedName string
+	origKill := killWindowFunc
+	defer func() { killWindowFunc = origKill }()
+	killWindowFunc = func(_, name string) error {
+		killedName = name
+		return nil
+	}
+
+	output := captureStdout(t, func() {
+		_ = runTmuxWindowKill(nil, []string{"editor"})
+	})
+
+	if killedName != "editor" {
+		t.Errorf("expected 'editor' to be killed, got %q", killedName)
+	}
+	if !strings.Contains(output, "editor") {
+		t.Errorf("expected 'editor' in success output, got: %s", output)
+	}
+}
+
+// TestRunTmuxWindowKill_UnknownName verifies that kill with a nonexistent name
+// returns a clear error.
+func TestRunTmuxWindowKill_UnknownName(t *testing.T) {
+	setupTmuxEnv(t)
+	windows := []tmux.Window{
+		{Index: 0, Name: "editor", Active: true},
+	}
+	setupWindowFuncs(t, windows, "dev")
+	t.Setenv("TMUX", "/tmp/tmux-test,12345,0")
+
+	err := runTmuxWindowKill(nil, []string{"nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for unknown window name, got nil")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("expected window name in error, got: %v", err)
+	}
+}
+
+// TestRunTmuxWindowKill_NoWindows verifies that kill returns an error when
+// there are no windows to kill.
+func TestRunTmuxWindowKill_NoWindows(t *testing.T) {
+	setupTmuxEnv(t)
+	setupWindowFuncs(t, []tmux.Window{}, "dev")
+	t.Setenv("TMUX", "/tmp/tmux-test,12345,0")
+
+	err := runTmuxWindowKill(nil, []string{})
+	if err == nil {
+		t.Fatal("expected error when no windows exist, got nil")
+	}
+}
+
+// TestRunTmuxWindowKill_NonTTY verifies that kill without a name on non-TTY
+// lists windows instead of failing.
+func TestRunTmuxWindowKill_NonTTY(t *testing.T) {
+	setupTmuxEnv(t)
+	windows := []tmux.Window{
+		{Index: 0, Name: "editor", Active: true},
+		{Index: 1, Name: "server", Active: false},
+	}
+	setupWindowFuncs(t, windows, "dev")
+	t.Setenv("TMUX", "/tmp/tmux-test,12345,0")
+
+	// IsTTY() returns false in tests, so the non-TTY listing branch runs.
+	output := captureStdout(t, func() {
+		_ = runTmuxWindowKill(nil, []string{})
+	})
+
+	if !strings.Contains(output, "editor") {
+		t.Errorf("expected window list in output, got: %s", output)
+	}
+}
+
+// --- mine tmux window rename ---
+
+// TestRunTmuxWindowRename_DirectRename verifies the 2-arg direct rename path.
+func TestRunTmuxWindowRename_DirectRename(t *testing.T) {
+	setupTmuxEnv(t)
+	setupWindowFuncs(t, nil, "dev")
+	t.Setenv("TMUX", "/tmp/tmux-test,12345,0")
+
+	var renamedOld, renamedNew string
+	origRename := renameWindowFunc
+	defer func() { renameWindowFunc = origRename }()
+	renameWindowFunc = func(_, old, new string) error {
+		renamedOld = old
+		renamedNew = new
+		return nil
+	}
+
+	output := captureStdout(t, func() {
+		_ = runTmuxWindowRename(nil, []string{"editor", "code"})
+	})
+
+	if renamedOld != "editor" || renamedNew != "code" {
+		t.Errorf("expected rename editor→code, got %q→%q", renamedOld, renamedNew)
+	}
+	if !strings.Contains(output, "editor") || !strings.Contains(output, "code") {
+		t.Errorf("expected both names in output, got: %s", output)
+	}
+}
+
+// TestRunTmuxWindowRename_EmptyNewName verifies that an empty new name in
+// 2-arg mode returns an error.
+func TestRunTmuxWindowRename_EmptyNewName(t *testing.T) {
+	setupTmuxEnv(t)
+	setupWindowFuncs(t, nil, "dev")
+	t.Setenv("TMUX", "/tmp/tmux-test,12345,0")
+
+	err := runTmuxWindowRename(nil, []string{"editor", ""})
+	if err == nil {
+		t.Fatal("expected error for empty new name, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot be empty") {
+		t.Errorf("expected 'cannot be empty' in error, got: %v", err)
+	}
+}
+
+// TestRunTmuxWindowRename_UnknownWindowInOneArgMode verifies that rename with
+// an unknown window name in 1-arg mode returns a clear error.
+func TestRunTmuxWindowRename_UnknownWindowInOneArgMode(t *testing.T) {
+	setupTmuxEnv(t)
+	windows := []tmux.Window{
+		{Index: 0, Name: "editor", Active: true},
+	}
+	setupWindowFuncs(t, windows, "dev")
+	t.Setenv("TMUX", "/tmp/tmux-test,12345,0")
+
+	err := runTmuxWindowRename(nil, []string{"nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for unknown window name, got nil")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("expected window name in error, got: %v", err)
+	}
+}
+
+// TestRunTmuxWindowRename_NoWindowsError verifies that rename (non-direct)
+// fails clearly when there are no windows.
+func TestRunTmuxWindowRename_NoWindowsError(t *testing.T) {
+	setupTmuxEnv(t)
+	setupWindowFuncs(t, []tmux.Window{}, "dev")
+	t.Setenv("TMUX", "/tmp/tmux-test,12345,0")
+
+	err := runTmuxWindowRename(nil, []string{"somename"})
+	if err == nil {
+		t.Fatal("expected error when no windows exist, got nil")
+	}
+}
+
+// TestRunTmuxWindowRename_NonTTY verifies that rename without args on non-TTY
+// lists windows instead of opening the picker.
+func TestRunTmuxWindowRename_NonTTY(t *testing.T) {
+	setupTmuxEnv(t)
+	windows := []tmux.Window{
+		{Index: 0, Name: "editor", Active: true},
+	}
+	setupWindowFuncs(t, windows, "dev")
+	t.Setenv("TMUX", "/tmp/tmux-test,12345,0")
+
+	// IsTTY() returns false in tests, so the non-TTY listing branch runs.
+	output := captureStdout(t, func() {
+		_ = runTmuxWindowRename(nil, []string{})
+	})
+
+	if !strings.Contains(output, "editor") {
+		t.Errorf("expected window list in output for non-TTY path, got: %s", output)
+	}
+}
+
+// --- arg validation ---
+
+func TestTmuxWindowNewCmdRequiresOneArg(t *testing.T) {
+	if err := tmuxWindowNewCmd.Args(tmuxWindowNewCmd, []string{}); err == nil {
+		t.Error("expected error for 0 args, got nil")
+	}
+	if err := tmuxWindowNewCmd.Args(tmuxWindowNewCmd, []string{"mywin"}); err != nil {
+		t.Errorf("expected 1 arg to be valid, got: %v", err)
+	}
+	if err := tmuxWindowNewCmd.Args(tmuxWindowNewCmd, []string{"a", "b"}); err == nil {
+		t.Error("expected error for 2 args, got nil")
+	}
+}
+
+func TestTmuxWindowKillCmdAcceptsZeroOrOneArg(t *testing.T) {
+	if err := tmuxWindowKillCmd.Args(tmuxWindowKillCmd, []string{}); err != nil {
+		t.Errorf("expected 0 args to be valid, got: %v", err)
+	}
+	if err := tmuxWindowKillCmd.Args(tmuxWindowKillCmd, []string{"win"}); err != nil {
+		t.Errorf("expected 1 arg to be valid, got: %v", err)
+	}
+	if err := tmuxWindowKillCmd.Args(tmuxWindowKillCmd, []string{"a", "b"}); err == nil {
+		t.Error("expected error for 2 args, got nil")
+	}
+}
+
+func TestTmuxWindowRenameCmdAcceptsUpToTwoArgs(t *testing.T) {
+	if err := tmuxWindowRenameCmd.Args(tmuxWindowRenameCmd, []string{}); err != nil {
+		t.Errorf("expected 0 args to be valid, got: %v", err)
+	}
+	if err := tmuxWindowRenameCmd.Args(tmuxWindowRenameCmd, []string{"a"}); err != nil {
+		t.Errorf("expected 1 arg to be valid, got: %v", err)
+	}
+	if err := tmuxWindowRenameCmd.Args(tmuxWindowRenameCmd, []string{"a", "b"}); err != nil {
+		t.Errorf("expected 2 args to be valid, got: %v", err)
+	}
+	if err := tmuxWindowRenameCmd.Args(tmuxWindowRenameCmd, []string{"a", "b", "c"}); err == nil {
+		t.Error("expected error for 3 args, got nil")
+	}
+}

--- a/internal/tmux/window.go
+++ b/internal/tmux/window.go
@@ -1,0 +1,130 @@
+package tmux
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Window represents a tmux window within a session.
+type Window struct {
+	Index  int
+	Name   string
+	Active bool
+}
+
+// FilterValue implements tui.Item for fuzzy matching.
+func (w Window) FilterValue() string { return w.Name }
+
+// Title implements tui.Item.
+func (w Window) Title() string { return w.Name }
+
+// Description implements tui.Item — index and active indicator.
+func (w Window) Description() string {
+	desc := fmt.Sprintf("index %d", w.Index)
+	if w.Active {
+		desc += "  (active)"
+	}
+	return desc
+}
+
+// CurrentSession returns the name of the currently attached tmux session.
+// Returns an error if not inside tmux or the query fails.
+var CurrentSession = currentSessionReal
+
+func currentSessionReal() (string, error) {
+	if !InsideTmux() {
+		return "", fmt.Errorf("not inside a tmux session")
+	}
+	out, err := tmuxCmd("display-message", "-p", "#{session_name}")
+	if err != nil {
+		return "", fmt.Errorf("getting current session name: %w", err)
+	}
+	name := strings.TrimSpace(out)
+	if name == "" {
+		return "", fmt.Errorf("could not determine current session name")
+	}
+	return name, nil
+}
+
+// ListWindows returns all windows in the named session.
+func ListWindows(session string) ([]Window, error) {
+	out, err := tmuxCmd("list-windows", "-t", session, "-F",
+		"#{window_index}\t#{window_name}\t#{window_active}")
+	if err != nil {
+		return nil, fmt.Errorf("listing windows for session %q: %w", session, err)
+	}
+	return parseWindows(out), nil
+}
+
+// NewWindow creates a new named window in the given session.
+func NewWindow(session, name string) error {
+	args := []string{"new-window", "-t", session}
+	if name != "" {
+		args = append(args, "-n", name)
+	}
+	_, err := tmuxCmd(args...)
+	if err != nil {
+		return fmt.Errorf("creating window %q in session %q: %w", name, session, err)
+	}
+	return nil
+}
+
+// KillWindow destroys the named window in the given session.
+func KillWindow(session, name string) error {
+	target := session + ":" + name
+	_, err := tmuxCmd("kill-window", "-t", target)
+	if err != nil {
+		return fmt.Errorf("killing window %q in session %q: %w", name, session, err)
+	}
+	return nil
+}
+
+// RenameWindow renames a window within a session from oldName to newName.
+func RenameWindow(session, oldName, newName string) error {
+	if newName == "" {
+		return fmt.Errorf("new window name cannot be empty")
+	}
+	target := session + ":" + oldName
+	_, err := tmuxCmd("rename-window", "-t", target, newName)
+	if err != nil {
+		return fmt.Errorf("renaming window %q to %q in session %q: %w", oldName, newName, session, err)
+	}
+	return nil
+}
+
+// FindWindowByName returns the window with the given exact name, or nil if not found.
+func FindWindowByName(name string, windows []Window) *Window {
+	for i := range windows {
+		if windows[i].Name == name {
+			return &windows[i]
+		}
+	}
+	return nil
+}
+
+// parseWindows parses tmux list-windows formatted output.
+func parseWindows(raw string) []Window {
+	if raw == "" {
+		return nil
+	}
+	var windows []Window
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) < 3 {
+			continue
+		}
+		index, _ := strconv.Atoi(parts[0])
+		active := parts[2] == "1"
+		windows = append(windows, Window{
+			Index:  index,
+			Name:   parts[1],
+			Active: active,
+		})
+	}
+	return windows
+}

--- a/internal/tmux/window_test.go
+++ b/internal/tmux/window_test.go
@@ -1,0 +1,323 @@
+package tmux
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseWindows(t *testing.T) {
+	raw := "0\teditor\t1\n1\tserver\t0\n2\ttests\t0\n"
+	windows := parseWindows(raw)
+
+	if len(windows) != 3 {
+		t.Fatalf("expected 3 windows, got %d", len(windows))
+	}
+
+	w := windows[0]
+	if w.Index != 0 {
+		t.Errorf("expected index 0, got %d", w.Index)
+	}
+	if w.Name != "editor" {
+		t.Errorf("expected name 'editor', got %q", w.Name)
+	}
+	if !w.Active {
+		t.Error("expected active=true for first window")
+	}
+
+	w2 := windows[1]
+	if w2.Index != 1 {
+		t.Errorf("expected index 1, got %d", w2.Index)
+	}
+	if w2.Name != "server" {
+		t.Errorf("expected name 'server', got %q", w2.Name)
+	}
+	if w2.Active {
+		t.Error("expected active=false for second window")
+	}
+}
+
+func TestParseWindows_Empty(t *testing.T) {
+	windows := parseWindows("")
+	if windows != nil {
+		t.Fatalf("expected nil for empty input, got %v", windows)
+	}
+}
+
+func TestParseWindows_Whitespace(t *testing.T) {
+	windows := parseWindows("  \n  \n")
+	if windows != nil {
+		t.Fatalf("expected nil for whitespace-only input, got %v", windows)
+	}
+}
+
+func TestParseWindows_MalformedLine(t *testing.T) {
+	// Lines with fewer than 3 tab-separated fields should be skipped.
+	raw := "bad-line\n0\tgood\t0\n"
+	windows := parseWindows(raw)
+
+	if len(windows) != 1 {
+		t.Fatalf("expected 1 window, got %d", len(windows))
+	}
+	if windows[0].Name != "good" {
+		t.Fatalf("expected name 'good', got %q", windows[0].Name)
+	}
+}
+
+func TestWindowItem(t *testing.T) {
+	w := Window{
+		Index:  2,
+		Name:   "editor",
+		Active: true,
+	}
+
+	if w.FilterValue() != "editor" {
+		t.Fatalf("FilterValue should return name, got %q", w.FilterValue())
+	}
+	if w.Title() != "editor" {
+		t.Fatalf("Title should return name, got %q", w.Title())
+	}
+
+	desc := w.Description()
+	if desc != "index 2  (active)" {
+		t.Fatalf("unexpected description: %q", desc)
+	}
+
+	// Test without active flag.
+	w.Active = false
+	desc = w.Description()
+	if desc != "index 2" {
+		t.Fatalf("unexpected description for inactive window: %q", desc)
+	}
+}
+
+func TestWindowItem_ZeroIndex(t *testing.T) {
+	w := Window{Index: 0, Name: "main", Active: false}
+	if w.Description() != "index 0" {
+		t.Fatalf("unexpected description: %q", w.Description())
+	}
+}
+
+func TestListWindows_Stubbed(t *testing.T) {
+	original := tmuxCmd
+	defer func() { tmuxCmd = original }()
+
+	var capturedArgs []string
+	tmuxCmd = func(args ...string) (string, error) {
+		capturedArgs = args
+		return "0\teditor\t1\n1\tserver\t0\n", nil
+	}
+
+	windows, err := ListWindows("mysession")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(windows) != 2 {
+		t.Fatalf("expected 2 windows, got %d", len(windows))
+	}
+
+	// Verify tmux was called with correct args.
+	if len(capturedArgs) < 3 || capturedArgs[0] != "list-windows" {
+		t.Fatalf("unexpected tmux args: %v", capturedArgs)
+	}
+	// -t mysession should be in args.
+	found := false
+	for i, a := range capturedArgs {
+		if a == "-t" && i+1 < len(capturedArgs) && capturedArgs[i+1] == "mysession" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected -t mysession in args, got: %v", capturedArgs)
+	}
+}
+
+func TestListWindows_Error(t *testing.T) {
+	original := tmuxCmd
+	defer func() { tmuxCmd = original }()
+
+	tmuxCmd = func(args ...string) (string, error) {
+		return "", fmt.Errorf("session not found")
+	}
+
+	_, err := ListWindows("nosuchsession")
+	if err == nil {
+		t.Fatal("expected error for failed list-windows, got nil")
+	}
+}
+
+func TestNewWindow_Stubbed(t *testing.T) {
+	original := tmuxCmd
+	defer func() { tmuxCmd = original }()
+
+	var capturedArgs []string
+	tmuxCmd = func(args ...string) (string, error) {
+		capturedArgs = args
+		return "", nil
+	}
+
+	if err := NewWindow("mysession", "editor"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify new-window args.
+	if capturedArgs[0] != "new-window" {
+		t.Fatalf("expected 'new-window', got %q", capturedArgs[0])
+	}
+	// Should include -t mysession and -n editor.
+	hasTarget := false
+	hasName := false
+	for i, a := range capturedArgs {
+		if a == "-t" && i+1 < len(capturedArgs) && capturedArgs[i+1] == "mysession" {
+			hasTarget = true
+		}
+		if a == "-n" && i+1 < len(capturedArgs) && capturedArgs[i+1] == "editor" {
+			hasName = true
+		}
+	}
+	if !hasTarget {
+		t.Fatalf("expected -t mysession in args, got: %v", capturedArgs)
+	}
+	if !hasName {
+		t.Fatalf("expected -n editor in args, got: %v", capturedArgs)
+	}
+}
+
+func TestNewWindow_EmptyName(t *testing.T) {
+	original := tmuxCmd
+	defer func() { tmuxCmd = original }()
+
+	var capturedArgs []string
+	tmuxCmd = func(args ...string) (string, error) {
+		capturedArgs = args
+		return "", nil
+	}
+
+	// Empty name should omit -n flag.
+	if err := NewWindow("mysession", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, a := range capturedArgs {
+		if a == "-n" {
+			t.Fatalf("expected no -n flag for empty name, got args: %v (flag at index %d)", capturedArgs, i)
+		}
+	}
+}
+
+func TestKillWindow_Stubbed(t *testing.T) {
+	original := tmuxCmd
+	defer func() { tmuxCmd = original }()
+
+	var capturedArgs []string
+	tmuxCmd = func(args ...string) (string, error) {
+		capturedArgs = args
+		return "", nil
+	}
+
+	if err := KillWindow("mysession", "editor"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(capturedArgs) != 3 ||
+		capturedArgs[0] != "kill-window" ||
+		capturedArgs[1] != "-t" ||
+		capturedArgs[2] != "mysession:editor" {
+		t.Fatalf("unexpected tmux args: %v", capturedArgs)
+	}
+}
+
+func TestKillWindow_Error(t *testing.T) {
+	original := tmuxCmd
+	defer func() { tmuxCmd = original }()
+
+	tmuxCmd = func(args ...string) (string, error) {
+		return "", fmt.Errorf("can't find window: editor")
+	}
+
+	err := KillWindow("mysession", "editor")
+	if err == nil {
+		t.Fatal("expected error for failed kill-window, got nil")
+	}
+}
+
+func TestRenameWindow_Stubbed(t *testing.T) {
+	original := tmuxCmd
+	defer func() { tmuxCmd = original }()
+
+	var capturedArgs []string
+	tmuxCmd = func(args ...string) (string, error) {
+		capturedArgs = args
+		return "", nil
+	}
+
+	if err := RenameWindow("mysession", "old", "new"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(capturedArgs) != 4 ||
+		capturedArgs[0] != "rename-window" ||
+		capturedArgs[1] != "-t" ||
+		capturedArgs[2] != "mysession:old" ||
+		capturedArgs[3] != "new" {
+		t.Fatalf("unexpected tmux args: %v", capturedArgs)
+	}
+}
+
+func TestRenameWindow_EmptyNewName(t *testing.T) {
+	err := RenameWindow("mysession", "old", "")
+	if err == nil {
+		t.Fatal("expected error for empty new name")
+	}
+	if err.Error() != "new window name cannot be empty" {
+		t.Fatalf("unexpected error message: %q", err.Error())
+	}
+}
+
+func TestRenameWindow_Error(t *testing.T) {
+	original := tmuxCmd
+	defer func() { tmuxCmd = original }()
+
+	tmuxCmd = func(args ...string) (string, error) {
+		return "", fmt.Errorf("can't find window: notexist")
+	}
+
+	err := RenameWindow("mysession", "notexist", "newname")
+	if err == nil {
+		t.Fatal("expected error when window not found")
+	}
+}
+
+func TestFindWindowByName_Found(t *testing.T) {
+	windows := []Window{
+		{Index: 0, Name: "editor"},
+		{Index: 1, Name: "server"},
+		{Index: 2, Name: "tests"},
+	}
+
+	w := FindWindowByName("server", windows)
+	if w == nil {
+		t.Fatal("expected to find window 'server', got nil")
+	}
+	if w.Name != "server" {
+		t.Fatalf("expected 'server', got %q", w.Name)
+	}
+}
+
+func TestFindWindowByName_NotFound(t *testing.T) {
+	windows := []Window{
+		{Index: 0, Name: "editor"},
+		{Index: 1, Name: "server"},
+	}
+
+	w := FindWindowByName("missing", windows)
+	if w != nil {
+		t.Fatalf("expected nil for missing window, got %v", w)
+	}
+}
+
+func TestFindWindowByName_Empty(t *testing.T) {
+	w := FindWindowByName("anything", nil)
+	if w != nil {
+		t.Fatalf("expected nil for empty window list, got %v", w)
+	}
+}

--- a/site/src/content/docs/commands/tmux.md
+++ b/site/src/content/docs/commands/tmux.md
@@ -134,6 +134,56 @@ mine tmux layout delete             # interactive picker (TTY)
 
 Permanently removes a saved layout. With no arguments, opens an interactive picker to select which layout to delete. Returns an error if the named layout does not exist.
 
+## Windows
+
+Manage windows within a tmux session. All window subcommands default to the current session when inside tmux. Use `--session <name>` to target a specific session.
+
+### List Windows
+
+```bash
+mine tmux window ls             # windows in current session
+mine tmux window ls --session s # windows in session "s"
+mine tmux window list           # alias
+```
+
+Lists all windows in the session with their index, name, and active indicator (`*`).
+
+### Create a Window
+
+```bash
+mine tmux window new <name>
+mine tmux window new editor --session myproject
+```
+
+Creates a new named window in the current (or specified) session.
+
+### Kill a Window
+
+```bash
+mine tmux window kill <name>     # kill by exact name
+mine tmux window kill            # interactive picker (TTY)
+mine tmux window kill --session s editor
+```
+
+Kills a window. With no name, opens an interactive fuzzy picker to select the window. Falls back to listing windows when stdout is not a TTY.
+
+### Rename a Window
+
+```bash
+mine tmux window rename old new  # rename directly, no prompts
+mine tmux window rename oldname  # select by name, then prompt for new name
+mine tmux window rename          # interactive picker, then prompt for new name
+mine tmux window rename --session s editor code
+```
+
+Renames a window. In 2-arg mode the rename is immediate. In 1-arg mode the window is matched by exact name and you are prompted for the new name. With no args, an interactive picker lets you select the window and then prompts for the new name.
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--session <name>` | Target session (defaults to current session inside tmux) |
+
 ## Examples
 
 ```bash
@@ -166,6 +216,12 @@ mine tmux layout load dev-3pane
 
 # Remove a layout you no longer need
 mine tmux layout delete dev-3pane
+
+# Manage windows within a session
+mine tmux window ls
+mine tmux window new editor
+mine tmux window kill old-window
+mine tmux window rename old-name new-name
 
 # Switch between sessions
 mine tmux


### PR DESCRIPTION
## Summary

Adds `mine tmux window` subcommands for window-level management within a tmux session: `ls`, `new`, `kill`, and `rename`. This completes the session management story — mine can now manage both sessions and the windows within those sessions. All commands default to the current tmux session and accept `--session <name>` to target a specific session.

Closes #103

## Changes

- **New files**:
  - `internal/tmux/window.go` — `Window` struct implementing `tui.Item`, domain functions (`ListWindows`, `NewWindow`, `KillWindow`, `RenameWindow`, `FindWindowByName`, `CurrentSession`), and `parseWindows` parser
  - `internal/tmux/window_test.go` — Unit tests for `parseWindows`, `Window` tui.Item interface, all domain functions (stubbed via `tmuxCmd`), and `FindWindowByName`
  - `cmd/tmux_window.go` — `tmuxWindowCmd` parent + 4 subcommands (`ls`, `new`, `kill`, `rename`), injectable function vars for testing, `resolveWindowSession` helper, `printWindowList` helper
  - `cmd/tmux_window_test.go` — Integration tests calling the actual `runTmuxWindow*` handlers end-to-end

- **Modified files**:
  - `site/src/content/docs/commands/tmux.md` — Added `## Windows` section documenting all four subcommands and `--session` flag

- **Architecture**:
  - `Window` struct follows the same `tui.Item` pattern as `Session` (FilterValue, Title, Description)
  - `CurrentSession` uses `tmux display-message -p "#{session_name}"` to resolve the current session name when inside tmux
  - Injectable function vars (`listWindowsFunc`, `newWindowFunc`, `killWindowFunc`, `renameWindowFunc`, `currentSessionFunc`) enable full test isolation without real tmux
  - `--session` flag is a persistent flag on `tmuxWindowCmd`, inherited by all subcommands
  - `cmd/tmux_window.go` is a separate file from `cmd/tmux.go` to keep files under 500 lines per project convention

## CLI Surface

- `mine tmux window ls` — list windows in current session (name, index, active indicator)
- `mine tmux window new <name>` — create a new named window
- `mine tmux window kill [name]` — kill by name or open TUI picker
- `mine tmux window rename [old] [new]` — 2-arg direct, 1-arg prompt, 0-arg picker+prompt
- Flags: `--session <name>` — available on all window subcommands; defaults to current session inside tmux

## Test Coverage

- Unit tests (`internal/tmux/window_test.go`):
  - `parseWindows`: normal, empty, whitespace-only, malformed lines
  - `Window.FilterValue`, `Title`, `Description` (active and inactive)
  - `ListWindows`, `NewWindow`, `KillWindow`, `RenameWindow` — all stubbed via `tmuxCmd` var
  - `FindWindowByName` — found, not found, empty list

- Integration tests (`cmd/tmux_window_test.go`):
  - `ls`: not-inside-tmux error, no windows, with `--session` flag, active marker in output
  - `new`: creates window, error propagation
  - `kill`: by-name, unknown name error, no windows error, non-TTY listing fallback
  - `rename`: 2-arg direct, empty new name, unknown window in 1-arg mode, no windows error, non-TTY listing fallback
  - Arg validation for all subcommands

## Acceptance Criteria

- [x] `mine tmux window ls` lists windows in current session (name, index, active indicator) — implemented in `runTmuxWindowLs`
- [x] `mine tmux window new <name>` creates a new window in current session — implemented in `runTmuxWindowNew`
- [x] `mine tmux window kill` opens TUI picker when no arg; `mine tmux window kill <name>` kills directly — implemented in `runTmuxWindowKill`
- [x] `mine tmux window rename` opens TUI picker then prompts for new name; 2-arg form renames directly — implemented in `runTmuxWindowRename`
- [x] All commands error clearly when not inside tmux — `resolveWindowSession` returns actionable error with `--session` hint
- [x] `--session <name>` flag available on all subcommands — implemented as persistent flag on `tmuxWindowCmd`
- [x] All subcommands hook-wrapped — each uses `hook.Wrap("tmux.window.*", ...)`
- [x] Unit tests in `internal/tmux/window_test.go`: `ListWindows` parse, `Window` tui.Item implementation — complete
- [x] `Window` struct implements `tui.Item` (FilterValue, Title, Description) — implemented
- [x] `site/src/content/docs/commands/tmux.md` — `window` subcommand section added

<!-- autodev-state: {"phase": "copilot", "copilot_iterations": 0} -->