### PR TITLE
ci: increase autodev dispatch frequency to 1 hour

### DIFF
--- a/.github/workflows/autodev-dispatch.yml
+++ b/.github/workflows/autodev-dispatch.yml
@@ -2,7 +2,7 @@ name: Autodev Dispatch
 
 on:
   schedule:
-    - cron: "0 */4 * * *"
+    - cron: "0 */1 * * *"
   workflow_dispatch:
     inputs:
       issue_number:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ For a comprehensive architecture deep-dive with diagrams, see
 
 Four workflows form the core loop, plus a weekly audit:
 
-1. **`autodev-dispatch`** — Runs on a 4-hour cron (or manual trigger). Picks the oldest
+1. **`autodev-dispatch`** — Runs on a 1-hour cron (or manual trigger). Picks the oldest
    `backlog/ready` issue, labels it `agent/implementing`, and triggers the implement workflow.
 2. **`autodev-implement`** — Checks out `main`, creates a branch, runs the agent (Claude
    via `claude-code-action@v1`) to implement the issue, pushes, and opens a PR.

--- a/docs/internal/LIFECYCLE.md
+++ b/docs/internal/LIFECYCLE.md
@@ -142,11 +142,11 @@ commit → open PR with verified acceptance criteria.
 **What it is**: An event-driven GitHub Actions pipeline with four workflows:
 `autodev-dispatch` → `autodev-implement` → `autodev-review-fix` → `claude-code-review`.
 
-**When to use**: Always-on background automation. Runs on a 4-hour cron without human
+**When to use**: Always-on background automation. Runs on a 1-hour cron without human
 input. The production autonomous pipeline.
 
 ```
-autodev-dispatch     — 4-hour cron (or manual trigger). Picks oldest backlog/ready
+autodev-dispatch     — 1-hour cron (or manual trigger). Picks oldest backlog/ready
                        issue, labels agent/implementing, triggers implement.
 autodev-implement    — Creates branch, runs agent, pushes, opens PR.
                        PR triggers CI + Copilot review.


### PR DESCRIPTION
## Summary

- Changes autodev-dispatch cron from every 4 hours to every 1 hour for faster issue throughput
- Updates corresponding references in CLAUDE.md and docs/internal/LIFECYCLE.md

## Test plan

- [ ] Verify cron syntax is valid (`0 */1 * * *`)
- [ ] Confirm workflow triggers on schedule after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)