### PR TITLE
ci: chain implement → review-fix and fix no-changes transition

### DIFF
--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -263,12 +263,50 @@ jobs:
 
       - name: Create PR
         if: steps.agent.outcome == 'success' && steps.changes.outputs.has_changes == 'true'
+        id: create-pr
         env:
           GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
         run: |
-          bash scripts/autodev/open-pr.sh \
+          PR_URL=$(bash scripts/autodev/open-pr.sh \
             "${{ inputs.issue_number }}" \
-            "${{ steps.prep.outputs.branch }}"
+            "${{ steps.prep.outputs.branch }}")
+
+          # Extract PR number from URL (e.g., https://github.com/rnwolfe/mine/pull/182)
+          PR_NUMBER=$(echo "$PR_URL" | grep -oP '/pull/\K\d+')
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      # ── Chain to review pipeline ──────────────────────────────────
+      # Bypasses the pull_request_review trigger which gets gated by
+      # GitHub's first-time contributor approval for bot actors (Copilot)
+      # on public repos. Polls for Copilot review, then dispatches
+      # review-fix directly.
+      - name: Wait for review and trigger review pipeline
+        if: steps.agent.outcome == 'success' && steps.changes.outputs.has_changes == 'true' && steps.create-pr.outputs.pr_number
+        env:
+          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.create-pr.outputs.pr_number }}"
+          echo "Waiting for Copilot review on PR #$PR_NUMBER..."
+
+          # Poll for up to 10 minutes (60 x 10s)
+          for i in $(seq 1 60); do
+            REVIEW_COUNT=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
+              --jq '[.[] | select(.user.login != "github-actions[bot]")] | length' 2>/dev/null || echo "0")
+
+            if [ "$REVIEW_COUNT" -gt 0 ]; then
+              echo "Review found after ~$((i * 10))s. Dispatching review-fix pipeline."
+              gh workflow run autodev-review-fix.yml \
+                --repo "${{ github.repository }}" \
+                -f pr_number="$PR_NUMBER"
+              echo "Review-fix pipeline dispatched for PR #$PR_NUMBER."
+              exit 0
+            fi
+
+            sleep 10
+          done
+
+          echo "::warning::No review appeared within 10 minutes. Review pipeline will rely on scheduled fallback."
 
       - name: Handle no changes
         if: steps.agent.outcome == 'success' && steps.changes.outputs.has_changes == 'false'

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -6,14 +6,23 @@ on:
   workflow_run:
     workflows: ["Claude Code Review"]
     types: [completed]
-  # Scheduled fallback: catches reviews from bot actors (e.g. Copilot) that
-  # get gated by GitHub's first-time contributor approval and never execute
-  # the pull_request_review trigger. Matches the autodev-dispatch cadence.
+  # Direct dispatch: implement workflow chains into review-fix after PR creation
+  # and Copilot review, bypassing the pull_request_review trigger that gets gated
+  # by GitHub's first-time contributor approval for bot actors on public repos.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to process"
+        required: true
+        type: string
+  # Scheduled fallback: catches edge cases where neither the direct dispatch
+  # nor pull_request_review triggers fire. Reduced importance since implement
+  # now chains directly, but kept as a safety net.
   schedule:
     - cron: "30 */4 * * *"
 
 concurrency:
-  group: autodev-review-fix-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || 'scheduled' }}
+  group: autodev-review-fix-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || inputs.pr_number || 'scheduled' }}
   cancel-in-progress: false
 
 permissions:
@@ -40,7 +49,10 @@ jobs:
           EVENT_REVIEW_BODY: ${{ github.event.review.body }}
         run: |
           # Resolve PR number based on event type
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ inputs.pr_number }}"
+            EVENT_SOURCE="dispatch"
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
             # Scheduled poll: find open autodev PRs not in "done" phase
             PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
               --state open --json number,body,labels \
@@ -106,8 +118,8 @@ jobs:
             exit 0
           fi
 
-          # For scheduled events: check reviews via API (no event context)
-          if [ "$EVENT_SOURCE" = "schedule" ]; then
+          # For scheduled/dispatch events: check reviews via API (no event context)
+          if [ "$EVENT_SOURCE" = "schedule" ] || [ "$EVENT_SOURCE" = "dispatch" ]; then
             # Get the latest review on this PR
             LATEST_REVIEW=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
               --jq '[.[] | select(.user.login != "github-actions[bot]")] | sort_by(.submitted_at) | last // empty')


### PR DESCRIPTION
## Summary

Fixes the ~4 hour bottleneck in the autodev review pipeline caused by GitHub's
first-time contributor approval gating on Copilot review events, and fixes a dead
state where copilot-fix producing no changes didn't transition to the Claude phase.

## Changes

### Implement → review-fix chaining (primary fix)
- **`.github/workflows/autodev-implement.yml`**: After creating a PR, the workflow now
  polls for a Copilot review (up to 10 minutes) and dispatches `autodev-review-fix`
  directly via `workflow_dispatch`. Captures PR number from `open-pr.sh` output.
- **`.github/workflows/autodev-review-fix.yml`**: Added `workflow_dispatch` trigger with
  `pr_number` input. Dispatch events route through the same API-based review checking
  as the scheduled poll path. Updated concurrency group to include dispatch PR number.

### No-changes transition fix
- **`.github/workflows/autodev-review-fix.yml`**: Added third condition to "Transition to
  Claude phase" step — fires when copilot-fix agent runs successfully but produces no
  changes (previously a dead state).

### Documentation
- **`CLAUDE.md`**: Updated pipeline flow diagram, implement description, and circuit
  breakers to document the chaining approach.
- **`docs/internal/autodev-pipeline.md`**: Updated architecture diagram, sequence diagram,
  workflow reference, circuit breakers table, and debugging guide.

## Architecture

The `pull_request_review` trigger gets gated by GitHub's first-time contributor approval
for bot actors (Copilot) on public repos. The chaining bypasses this:

```
implement → create PR → poll for review (≤10 min) → dispatch review-fix
```

The 4-hour scheduled poll remains as a safety-net fallback.

## Test Plan

- [ ] Trigger autodev-dispatch with a `backlog/ready` issue
- [ ] Verify implement creates PR and polls for Copilot review
- [ ] Verify review-fix is dispatched and processes the review
- [ ] Verify the full pipeline completes to `human/review-merge`