### PR TITLE
feat: deploy analytics ingest backend as Vercel Edge Function

### DIFF
--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -100,4 +100,5 @@ const (
 	IconCalendar = "📅"
 	IconSettings = "⚙️ "
 	IconParty    = "🎉"
+	IconPick     = "◆ "
 )

--- a/site/api/README.md
+++ b/site/api/README.md
@@ -1,0 +1,84 @@
+# Analytics Ingest API
+
+This directory contains Vercel Edge Functions for the `mine` analytics backend.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v1/events` | Receive anonymous usage pings from `mine` binaries |
+
+## Architecture
+
+```
+mine binary → POST analytics.mine.rwolfe.io/v1/events
+                  → Edge Function (validate, strip IP, transform)
+                      → POST PostHog Capture API
+```
+
+The edge function:
+- Validates the incoming payload (required fields, correct types)
+- Strips the client IP — `$ip: null` is sent to PostHog, fulfilling the privacy commitment in the docs
+- Forwards to PostHog Cloud under the `command_run` event name
+- Always returns `202 Accepted` to the caller for valid requests; PostHog errors are swallowed silently to match the client's fail-silent behaviour
+
+## Human Setup Steps
+
+These steps must be completed manually before the endpoint is live.
+
+### 1. Create a PostHog Cloud project
+
+1. Go to [posthog.com](https://posthog.com) and sign up or log in
+2. Create a new project (e.g. `mine`)
+3. Copy the **Project API Key** — it starts with `phc_`
+
+### 2. Add the environment variable in Vercel
+
+1. Open the [Vercel dashboard](https://vercel.com) → select the `mine` project
+2. Go to **Settings → Environment Variables**
+3. Add a new variable:
+   - **Name**: `POSTHOG_API_KEY`
+   - **Value**: your `phc_...` key
+   - **Environments**: Production (and Preview if desired)
+4. Save — no redeployment needed for edge functions; the var is read at runtime
+
+### 3. Add the analytics domain alias
+
+1. In the Vercel dashboard → project → **Settings → Domains**
+2. Add `analytics.mine.rwolfe.io` as a domain alias
+
+### 4. Configure DNS
+
+Add a CNAME record in your DNS provider:
+
+| Type | Name | Value |
+|------|------|-------|
+| `CNAME` | `analytics` | `cname.vercel-dns.com` |
+
+Once DNS propagates, `https://analytics.mine.rwolfe.io/v1/events` will route to the edge function.
+
+## Payload Schema
+
+The `mine` binary sends this JSON body on each command invocation (at most once per command per day):
+
+```json
+{
+  "install_id": "uuid-v4",
+  "version": "0.1.0",
+  "os": "linux",
+  "arch": "amd64",
+  "command": "todo",
+  "date": "2026-02-17"
+}
+```
+
+All fields are required. The endpoint returns `400` if any are missing or empty.
+
+## Response Codes
+
+| Code | Meaning |
+|------|---------|
+| `202` | Event accepted and forwarded to PostHog |
+| `400` | Malformed or missing required fields |
+| `405` | Non-POST method |
+| `500` | `POSTHOG_API_KEY` not configured |

--- a/site/api/v1/events.ts
+++ b/site/api/v1/events.ts
@@ -1,0 +1,99 @@
+/**
+ * Analytics ingest endpoint — Vercel Edge Function
+ *
+ * Accepts POST /v1/events with mine's anonymous usage payload,
+ * validates it, and forwards to PostHog Cloud.
+ *
+ * Privacy: client IP is never forwarded ($ip: null sent to PostHog).
+ * PostHog errors are swallowed — the endpoint always returns 2xx on
+ * valid input to match the client's fail-silent behaviour.
+ */
+
+export const config = { runtime: "edge" };
+
+interface MinePayload {
+  install_id: string;
+  version: string;
+  os: string;
+  arch: string;
+  command: string;
+  date: string;
+}
+
+const REQUIRED_FIELDS: (keyof MinePayload)[] = [
+  "install_id",
+  "version",
+  "os",
+  "arch",
+  "command",
+  "date",
+];
+
+const POSTHOG_CAPTURE_URL = "https://us.i.posthog.com/capture/";
+
+export default async function handler(req: Request): Promise<Response> {
+  // Only accept POST
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  // Check POSTHOG_API_KEY is configured
+  const apiKey = process.env.POSTHOG_API_KEY;
+  if (!apiKey) {
+    return new Response("Internal Server Error: analytics not configured", {
+      status: 500,
+    });
+  }
+
+  // Parse and validate the request body
+  let payload: MinePayload;
+  try {
+    const body = await req.json();
+    if (typeof body !== "object" || body === null || Array.isArray(body)) {
+      return new Response("Bad Request: payload must be a JSON object", {
+        status: 400,
+      });
+    }
+    payload = body as MinePayload;
+  } catch {
+    return new Response("Bad Request: invalid JSON", { status: 400 });
+  }
+
+  // Validate required fields are present and non-empty strings
+  for (const field of REQUIRED_FIELDS) {
+    const value = payload[field];
+    if (typeof value !== "string" || value.trim() === "") {
+      return new Response(
+        `Bad Request: missing or empty required field: ${field}`,
+        { status: 400 }
+      );
+    }
+  }
+
+  // Forward to PostHog — errors are swallowed to match client fail-silent behaviour
+  const posthogPayload = {
+    api_key: apiKey,
+    event: "command_run",
+    distinct_id: payload.install_id,
+    properties: {
+      version: payload.version,
+      os: payload.os,
+      arch: payload.arch,
+      command: payload.command,
+      date: payload.date,
+      $ip: null, // Suppress IP storage — privacy commitment
+    },
+  };
+
+  try {
+    await fetch(POSTHOG_CAPTURE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(posthogPayload),
+    });
+  } catch {
+    // PostHog unreachable — still return 202 to caller
+  }
+
+  return new Response(null, { status: 202 });
+}


### PR DESCRIPTION
## Summary

Deploys the analytics ingest backend that the `mine` binary already targets. The client-side code ships in every binary and has been silently failing against the missing `https://analytics.mine.rwolfe.io/v1/events` endpoint. This PR adds a thin Vercel Edge Function relay that validates the payload, strips the client IP, and forwards to PostHog Cloud — fulfilling the privacy commitment already documented for users.

Closes #110

## Changes

- **New files**:
  - `site/api/v1/events.ts` — Vercel Edge Function that accepts `POST /v1/events`, validates the mine payload schema, strips client IP (`$ip: null`), and relays to PostHog Capture API. Always returns `202` to caller for valid payloads (PostHog errors are swallowed silently to match client behaviour).
  - `site/api/README.md` — Human setup guide covering PostHog project creation, Vercel environment variable, domain alias, and DNS configuration.

- **Modified files**:
  - `internal/ui/theme.go` — Added missing `IconPick` constant (`"◆ "`) that was referenced in `cmd/tmux.go` but never defined, causing a pre-existing build failure.

- **Architecture**:
  - The edge function uses `export const config = { runtime: 'edge' }` — auto-detected by Vercel from the `site/api/` directory with no `vercel.json` changes required.
  - Method guard (405 for non-POST), payload validation (400 for missing/empty required fields), config guard (500 if `POSTHOG_API_KEY` unset), then forward with `$ip: null` and return 202.
  - PostHog errors are intentionally swallowed — the relay always returns 2xx for valid input to preserve the fail-silent guarantee the client depends on for dedup logic.

## CLI Surface

No new CLI commands or flags. This is backend infrastructure only.

## Test Coverage

- All existing Go tests pass (`make test` clean).
- The edge function is TypeScript targeting the Vercel Edge runtime; Go test suite does not cover it. The logic is straightforward enough to verify by inspection: method check → env check → JSON parse → field validation → PostHog relay → 202.

## Acceptance Criteria

Verified against issue #110:

- [x] `site/api/v1/events.ts` created as a Vercel Edge Function (`export const config = { runtime: 'edge' }`)
- [x] Function accepts `POST /v1/events` with the mine JSON payload schema — all six required fields validated
- [x] Returns `202 Accepted` on success; always returns `2xx` to caller (PostHog errors are swallowed silently)
- [x] Returns `400` if required fields are missing or payload is malformed (invalid JSON or missing/empty fields)
- [x] Rejects non-POST methods with `405`
- [x] Client IP is never forwarded — `$ip: null` sent to PostHog
- [x] `POSTHOG_API_KEY` env var read at runtime; function returns `500` if not configured
- [x] Human setup steps documented in `site/api/README.md` (PostHog account, Vercel env var, domain alias, DNS)

<!-- autodev-state: {"phase": "done", "copilot_iterations": 0} -->