### PR TITLE
fix: repair autodev dispatch chain and Claude review visibility

### DIFF
--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -301,10 +301,13 @@ jobs:
 
             if [ "$REVIEW_COUNT" -gt 0 ]; then
               echo "Review found after ~$((i * 10))s. Dispatching review-fix pipeline."
-              gh workflow run autodev-review-fix.yml \
+              if gh workflow run autodev-review-fix.yml \
                 --repo "${{ github.repository }}" \
-                -f pr_number="$PR_NUMBER"
-              echo "Review-fix pipeline dispatched for PR #$PR_NUMBER."
+                -f pr_number="$PR_NUMBER"; then
+                echo "Review-fix pipeline dispatched for PR #$PR_NUMBER."
+              else
+                echo "::warning::Failed to dispatch review-fix (AUTODEV_TOKEN needs 'actions: write' permission). The 4-hour scheduled fallback will process this PR."
+              fi
               exit 0
             fi
 

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -436,8 +436,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Exclude Copilot's reviews so only Claude's github-actions[bot] review is seen.
           bash scripts/autodev/parse-reviews.sh \
-            "${{ steps.route.outputs.pr_number }}" > /tmp/review-feedback.txt || true
+            "${{ steps.route.outputs.pr_number }}" \
+            "copilot-pull-request-reviewer[bot]" > /tmp/review-feedback.txt || true
 
           if [ ! -s /tmp/review-feedback.txt ]; then
             echo "No review feedback found after Claude review. Marking done."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,35 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}'
+          prompt: |
+            Review PR #${{ steps.pr.outputs.number }} in ${{ github.repository }}.
+
+            Steps:
+            1. Fetch the PR metadata and diff:
+               gh pr view ${{ steps.pr.outputs.number }} --repo ${{ github.repository }} --json title,body,additions,deletions,changedFiles
+               gh pr diff ${{ steps.pr.outputs.number }} --repo ${{ github.repository }}
+
+            2. Read CLAUDE.md for project conventions.
+
+            3. Review all changes, checking for:
+               - Logic errors and correctness
+               - Security issues (injection, path traversal, hardcoded secrets, OWASP top 10)
+               - Test coverage for new functionality (unit + integration per CLAUDE.md standards)
+               - Adherence to CLAUDE.md patterns (domain separation, store pattern, UI consistency, error message standards)
+               - File size limits (< 500 lines per file)
+               - Documentation updates required when features/commands are added or modified
+
+            4. You MUST post a formal PR review — the pipeline depends on it to decide next steps.
+
+               If the PR is clean (no issues):
+               gh pr review ${{ steps.pr.outputs.number }} --repo ${{ github.repository }} --comment \
+                 --body $'## Claude Code Review\n\nLGTM — no issues found.\n\n[Brief summary of what was reviewed and why it\'s acceptable]'
+
+               If there are blocking issues that MUST be fixed:
+               gh pr review ${{ steps.pr.outputs.number }} --repo ${{ github.repository }} --request-changes \
+                 --body $'## Claude Code Review\n\n[Summary of issues]\n\n### Required changes\n- Issue 1\n- Issue 2'
+
+               If there are non-blocking suggestions only:
+               gh pr review ${{ steps.pr.outputs.number }} --repo ${{ github.repository }} --comment \
+                 --body $'## Claude Code Review\n\n[Summary] Suggestions below are non-blocking.\n\n### Suggestions\n- Suggestion 1'
+          claude_args: "--model claude-sonnet-4-6 --max-turns 20 --dangerously-skip-permissions"


### PR DESCRIPTION
## Summary

- Fixes the implement workflow failing when `AUTODEV_TOKEN` lacks `actions: write` — now a non-fatal warning instead of a hard failure
- Fixes Claude Code Review producing no visible PR artifact — replaces the opaque plugin with a direct prompt that posts a formal `gh pr review`
- Fixes the claude-fix feedback parser always returning empty — flips the exclude-login so Claude's `github-actions[bot]` review is included and Copilot's is excluded

Diagnosed from PR #185 where the implement run was marked ❌ due to a 403 on dispatch, Claude's review cost $2.83 but left no trace on the PR, and the pipeline finalized as "done" with zero feedback acted upon.

## Changes

- **`.github/workflows/autodev-implement.yml`** — `gh workflow run` failure is now a `::warning::` with a descriptive message; the implement run no longer turns red for a PAT config issue
- **`.github/workflows/claude-code-review.yml`** — drops `code-review@claude-code-plugins`; new direct prompt requires Claude to post `gh pr review --comment` or `--request-changes` before finishing; `max-turns` reduced from 50 → 20 (review only, no implementation)
- **`scripts/autodev/parse-reviews.sh`** — adds optional `EXCLUDE_LOGIN` arg (default: `github-actions[bot]`); uses `jq --arg` for safe interpolation in both reviews and inline-comments queries
- **`.github/workflows/autodev-review-fix.yml`** — claude-fix path passes `copilot-pull-request-reviewer[bot]` as the exclude so Claude's review is now readable by the fix agent

## Test plan

- [ ] Trigger autodev on a new issue — implement run should stay ✅ even if dispatch was already working
- [ ] Confirm Claude Code Review posts a visible review on the PR (check Reviews tab)
- [ ] Confirm review-fix claude-fix path reads Claude's feedback and either fixes or marks done with real feedback
- [ ] Confirm copilot-fix path still correctly reads only Copilot's inline comments (not Claude's)

🤖 Generated with [Claude Code](https://claude.com/claude-code)