### PR TITLE
fix: repair parse-reviews.sh --jq --arg bug and add error detection

### DIFF
--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -269,8 +269,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bash scripts/autodev/parse-reviews.sh \
-            "${{ steps.route.outputs.pr_number }}" > /tmp/review-feedback.txt || true
+          if ! bash scripts/autodev/parse-reviews.sh \
+            "${{ steps.route.outputs.pr_number }}" > /tmp/review-feedback.txt; then
+            echo "::error::parse-reviews.sh failed — gh API or jq error. Transitioning to claude phase as fallback."
+            echo "override_action=trigger-claude" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [ ! -s /tmp/review-feedback.txt ]; then
             echo "No actionable feedback found. Transitioning to claude phase."
@@ -437,9 +441,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Exclude Copilot's reviews so only Claude's github-actions[bot] review is seen.
-          bash scripts/autodev/parse-reviews.sh \
+          if ! bash scripts/autodev/parse-reviews.sh \
             "${{ steps.route.outputs.pr_number }}" \
-            "copilot-pull-request-reviewer[bot]" > /tmp/review-feedback.txt || true
+            "copilot-pull-request-reviewer[bot]" > /tmp/review-feedback.txt; then
+            echo "::error::parse-reviews.sh failed — gh API or jq error. Cannot extract Claude review feedback."
+            echo "::error::Review feedback was NOT addressed. Manual intervention required."
+            exit 1
+          fi
 
           if [ ! -s /tmp/review-feedback.txt ]; then
             echo "No review feedback found after Claude review. Marking done."


### PR DESCRIPTION
## Summary

- **Root cause of PR #194 ghost-merge**: `parse-reviews.sh` used `gh api --jq --arg exclude "$EXCLUDE_LOGIN"`, which is invalid syntax. `gh api` doesn't accept `--arg`; that's a `jq` CLI flag. The result was `gh` erroring with "accepts 1 arg(s), received 4", the script exiting non-zero, and the `|| true` in the workflow silently swallowing it — leaving an empty feedback file that the pipeline interpreted as "no feedback found".
- **Impact**: Both the copilot-fix and claude-fix review cycles on every autodev PR were silently skipped. PR #194 accumulated two CHANGES_REQUESTED reviews with zero fix commits before being incorrectly labeled `human/review-merge`.

## Changes

**`scripts/autodev/parse-reviews.sh`**
- Fix both `gh api` calls: pipe through `jq` instead of using `gh api --jq --arg`
- Change "no feedback" exit code from `1` → `0` so callers can distinguish "nothing found" from "script crashed"

**`.github/workflows/autodev-review-fix.yml`**
- **Copilot-fix path**: replace `|| true` with explicit error detection — script failure now logs `::error::` and escalates to claude phase as a graceful fallback
- **Claude-fix path**: replace `|| true` with hard `exit 1` — if feedback extraction fails in the final review cycle the step fails visibly instead of marking the PR done

## Test plan

- [x] `parse-reviews.sh` with a real PR number works end-to-end (jq receives proper input via pipe)
- [x] `parse-reviews.sh` exit codes: 0 + content for feedback, 0 + empty for no feedback, 1 for errors
- [x] Workflow copilot-fix path: `::error::` logged and `override_action=trigger-claude` set on script failure
- [x] Workflow claude-fix path: step fails with visible error on script failure instead of silently marking done

Fixes the pipeline regression that caused PR #194 to be marked ready-for-merge with unaddressed review feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)