### PR TITLE
fix: prevent duplicate review-fix runs and allowed_bots rejection for bot actors

### DIFF
--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -182,6 +182,17 @@ jobs:
           REVIEW_STATE="${{ github.event.review.state }}"
           echo "reviewer=$REVIEWER" >> "$GITHUB_OUTPUT"
 
+          # Skip bot reviewers entirely on pull_request_review. Bot phases are handled by
+          # dedicated triggers: copilot → workflow_dispatch (from implement), claude →
+          # workflow_run (after Claude Code Review completes). Allowing pull_request_review
+          # to fire for bots causes duplicate fix runs — each review comment Claude posts
+          # triggers a separate pull_request_review event.
+          if [[ "$REVIEWER" == *"[bot]"* ]] || [ "$REVIEWER" = "claude" ]; then
+            echo "Skipping pull_request_review from bot reviewer: $REVIEWER (handled by workflow_run/dispatch)"
+            echo "action=skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           IS_COPILOT=false
           if [ "$REVIEWER" = "Copilot" ] || [ "$REVIEWER" = "copilot-pull-request-reviewer[bot]" ]; then
             IS_COPILOT=true
@@ -302,7 +313,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "github-actions[bot]"
+          allowed_bots: "github-actions[bot],claude"
           prompt: |
             You are fixing Copilot review feedback on PR #${{ steps.route.outputs.pr_number }} for the mine CLI tool.
 
@@ -472,7 +483,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "github-actions[bot]"
+          allowed_bots: "github-actions[bot],claude"
           prompt: |
             You are doing a final review-fix pass on PR #${{ steps.route.outputs.pr_number }} for the mine CLI tool.
             This is the last automated fix cycle — make it count.


### PR DESCRIPTION
## Summary

Two related autodev pipeline bugs observed on PRs #198 and others:

- **`allowed_bots` rejection**: When `autodev-review-fix` is triggered by `workflow_run` (after Claude Code Review completes), `github.actor` is `claude`. Both agent steps had `allowed_bots: "github-actions[bot]"` only — causing the action to reject execution with: *"Workflow initiated by non-human actor: claude (type: Bot)."* Fix: added `claude` to `allowed_bots` on both `copilot-fix` and `claude-fix` steps.

- **Duplicate fix runs**: `pull_request_review` fires once per review comment a bot posts. Claude posting 8 inline comments = 8 separate workflow triggers, each routing to `claude-fix` — duplicating the `workflow_run` trigger that fires when the full Claude Code Review run completes. This also caused Claude Code Review to run multiple times (observed on PR #198: LGTM posted twice, error comments posted twice). Fix: skip `pull_request_review` events from bot actors (`[bot]` suffix or login `claude`) at the top of the route script. Bot phases have dedicated triggers: copilot via `workflow_dispatch` (from implement), claude via `workflow_run`.

## Changes

- `.github/workflows/autodev-review-fix.yml`
  - `allowed_bots: "github-actions[bot]"` → `allowed_bots: "github-actions[bot],claude"` on both agent steps
  - Added bot-reviewer skip at top of `pull_request_review` route path
- `docs/internal/autodev-pipeline.md` — updated triggers table, safety features, circuit breakers table, debugging guide, and lessons reference table
- `docs/internal/lessons-learned.md` — added L-020 (bot review events cause duplicate runs) and L-021 (`allowed_bots` must include `claude` for `workflow_run`-triggered steps)

## Acceptance Criteria

- [x] Claude fix agent no longer rejected with `allowed_bots` error when triggered via `workflow_run`
- [x] Bot-submitted `pull_request_review` events no longer trigger duplicate fix runs
- [x] Both agent steps (copilot-fix and claude-fix) updated consistently
- [x] Internal docs updated with root-cause analysis and new lessons

## Test plan

- [ ] Verify next autodev PR: no duplicate Claude review comments, no `allowed_bots` error in workflow logs
- [ ] Verify `pull_request_review` from humans still routes correctly (no regression on human review path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)