### PR TITLE
fix: transition to Claude phase after committed copilot-fix

### DIFF
--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -408,12 +408,17 @@ jobs:
       # Transitions to Claude when:
       # 1. Router decided to trigger-claude (no Copilot comments or max iterations)
       # 2. Feedback extraction found nothing actionable (override)
-      # 3. Copilot fix agent ran but produced no changes (agent couldn't address feedback → escalate)
+      # 3. Copilot fix agent ran successfully — regardless of whether changes were committed.
+      #    With changes: all Copilot comments were addressed; no re-review needed (L-027).
+      #    Without changes: agent found nothing to fix; escalate to Claude.
+      #    Previously only case 3b (no changes) was handled, leaving PRs stuck in copilot
+      #    phase indefinitely after a committed fix because pull_request_review from Copilot
+      #    is filtered (L-020) and the 4h fallback sees "commit newer than review" and skips.
       - name: Transition to Claude phase
         if: |
           steps.route.outputs.action == 'trigger-claude'
           || steps.copilot-feedback.outputs.override_action == 'trigger-claude'
-          || (steps.route.outputs.action == 'copilot-fix' && steps.copilot-feedback.outputs.override_action != 'trigger-claude' && steps.copilot-agent.outcome == 'success' && steps.copilot-changes.outputs.has_changes == 'false')
+          || (steps.route.outputs.action == 'copilot-fix' && steps.copilot-feedback.outputs.override_action != 'trigger-claude' && steps.copilot-agent.outcome == 'success')
         env:
           GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
         run: |

--- a/docs/internal/lessons-learned.md
+++ b/docs/internal/lessons-learned.md
@@ -172,7 +172,7 @@ access. For sync pull redistribution, use `SyncPullWithResult()` as the primary 
 point (returns a summary), with `SyncPull()` delegating to it — keeps callers simple
 while allowing detailed output in the cmd layer.
 
-### L-024: Project-level vs global agent config disambiguation
+### L-026: Project-level vs global agent config disambiguation
 
 When implementing project-level scaffolding alongside global agent management, use a
 separate spec registry (`buildProjectSpecRegistry`) rather than extending the global
@@ -189,4 +189,14 @@ For `project init` + `project link` workflows: init creates the directory struct
 (including empty skill dirs), and link replaces those dirs with symlinks to the canonical
 store. Since init already created the dirs, link requires `--force` to proceed. Document
 this in the command help text so users understand the two-step workflow.
+
+### L-027: Copilot fix loop — missing transition to Claude after committed changes
+After a successful `copilot-fix` run where Claude commits changes, the autodev pipeline
+got stuck: the "Transition to Claude phase" step only fired when `has_changes == 'false'`
+(agent ran but made no changes). With `has_changes == 'true'` (fix committed), the step
+was skipped, leaving the PR in `copilot` phase indefinitely. The `pull_request_review`
+trigger from Copilot's second review is filtered out (bot filter, L-020), and the 4-hour
+fallback sees "latest commit is newer than review" and skips. Fix: also trigger the
+Claude transition when copilot-fix succeeds with committed changes — one Copilot pass +
+one Claude fix is sufficient; Copilot re-review is not required when all comments are addressed.
 


### PR DESCRIPTION
## Summary

Closes a pipeline gap where PRs got permanently stuck after a successful Copilot fix.

**Root cause**: After `copilot-fix` ran and Claude committed changes, the "Transition to Claude phase" step required `has_changes == 'false'` to fire. With `has_changes == 'true'` (fix committed), nothing transitioned the PR to Claude phase.

**Why it stayed stuck**: The `pull_request_review` from Copilot's second review is bot-filtered (L-020). The 4-hour fallback saw "latest commit (Claude's fix) is newer than the review" and skipped. PR remained in `copilot` phase indefinitely.

**Fix**: Trigger the Claude transition whenever `copilot-fix` agent succeeds — regardless of `has_changes`. If changes were committed, all Copilot comments were addressed and no re-review is needed. If no changes, behavior is unchanged (escalate).

Also fixes a L-024 numbering conflict introduced by an autodev PR (renumbered to L-026) and adds L-027 documenting this bug.

## Changes

- **`.github/workflows/autodev-review-fix.yml`**: Simplify "Transition to Claude phase" condition — `copilot-fix` success always transitions, not just when `has_changes == 'false'`
- **`docs/internal/lessons-learned.md`**: Fix L-024 duplicate → L-026, add L-027

## Before / After

**Before**: copilot-fix commits changes → counter=1 → job ends → PR stuck  
**After**: copilot-fix commits changes → counter=1 → transition to Claude → Claude Code Review triggered

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>