### PR TITLE
fix: prevent duplicate finalization when schedule races workflow_run

### DIFF
--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -22,6 +22,10 @@ on:
     - cron: "30 */4 * * *"
 
 concurrency:
+  # schedule uses 'scheduled' as the group key (PR number is unknown at trigger time),
+  # so it can run concurrently with workflow_run/dispatch runs for the same PR.
+  # The Finalize step uses an idempotency guard (human/review-merge label check) to
+  # prevent duplicate completion comments when concurrent runs both reach the done phase.
   group: autodev-review-fix-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || inputs.pr_number || 'scheduled' }}
   cancel-in-progress: false
 
@@ -574,6 +578,17 @@ jobs:
           GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
         run: |
           PR_NUMBER="${{ steps.route.outputs.pr_number }}"
+
+          # Idempotency guard: re-read current state to prevent duplicate finalization.
+          # schedule and workflow_run use different concurrency groups so they can run
+          # concurrently. Both may see phase=="claude" before either updates it to "done".
+          CURRENT_LABELS=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json labels --jq '[.labels[].name]')
+          if echo "$CURRENT_LABELS" | jq -e 'index("human/review-merge")' >/dev/null 2>&1; then
+            echo "PR #$PR_NUMBER already finalized (human/review-merge label present). Skipping duplicate."
+            exit 0
+          fi
 
           # Update phase to done in PR body
           PR_BODY=$(gh pr view "$PR_NUMBER" \


### PR DESCRIPTION
## Summary

Fixes duplicate "Autodev review pipeline complete" comments on autodev PRs (seen on PR #214).

**Root cause**: The `schedule` trigger uses `'scheduled'` as its concurrency group (PR number is unknown at trigger time). This means a scheduled run and a `workflow_run`-triggered run for the same PR can execute the `Finalize — mark phase done` step concurrently. Both see `phase == 'claude'`, both post the completion comment, and both try to enable auto-merge.

**Fix**: Add an idempotency guard at the start of the finalize step. Before doing anything, re-read the PR's labels. If `human/review-merge` is already present, another run finalized first — exit cleanly.

**Why not fix the concurrency group?** The schedule's PR number is resolved inside the job (can't be used in the concurrency expression), so changing the group would require a two-job split. The idempotency guard is simpler and just as correct.

Also adds a comment on the concurrency group explaining the known limitation, and L-028 to lessons-learned.md.

## Changes

- **`.github/workflows/autodev-review-fix.yml`**: Idempotency guard + concurrency comment
- **`docs/internal/lessons-learned.md`**: L-028

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>