### PR TITLE
chore: personality audit — warm up flat Short fields and fix brand violations

### DIFF
--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -12,7 +12,7 @@ import (
 
 var agentsCmd = &cobra.Command{
 	Use:   "agents",
-	Short: "Manage coding agent configurations from a canonical store",
+	Short: "One store for all your coding agent configs — skills, rules, and instructions",
 	Long:  `Manage your coding agent configurations with a single canonical store of instructions, rules, and skills.`,
 	RunE:  hook.Wrap("agents", runAgentsStatus),
 }
@@ -70,19 +70,19 @@ func init() {
 
 var agentsInitCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Create the canonical agents store with a starter directory structure",
+	Short: "Set up your canonical agents store for the first time",
 	RunE:  hook.Wrap("agents.init", runAgentsInit),
 }
 
 var agentsDetectCmd = &cobra.Command{
 	Use:   "detect",
-	Short: "Scan for installed coding agents and persist results to the manifest",
+	Short: "Find installed coding agents on your machine",
 	RunE:  hook.Wrap("agents.detect", runAgentsDetect),
 }
 
 var agentsLinkCmd = &cobra.Command{
 	Use:   "link",
-	Short: "Create symlinks from the canonical store to each detected agent's config locations",
+	Short: "Wire your canonical configs into each detected agent",
 	Long: `Create symlinks from the canonical agents store to each detected agent's
 expected configuration locations. Only config types that exist in the store are linked
 (e.g. skips skills/ if it is empty). Use --copy to create file copies instead of
@@ -92,7 +92,7 @@ symlinks. Use --force to overwrite existing non-symlink files.`,
 
 var agentsUnlinkCmd = &cobra.Command{
 	Use:   "unlink",
-	Short: "Replace symlinks with standalone copies, restoring independent configs",
+	Short: "Restore agents to independent configs — break the canonical link",
 	Long: `Replace agent config symlinks with standalone file copies, restoring each
 agent's configuration to an independent state. After unlinking, changes to the
 canonical store will no longer propagate to the agent configs.`,
@@ -101,7 +101,7 @@ canonical store will no longer propagate to the agent configs.`,
 
 var agentsAdoptCmd = &cobra.Command{
 	Use:   "adopt",
-	Short: "Scan detected agents for existing configs and import them to the canonical store",
+	Short: "Import existing agent configs into your canonical store",
 	Long: `Scan detected agents for existing configs, import them into the canonical
 store, and replace originals with symlinks. This is the zero-friction migration path
 for developers who already have agent configs in place.
@@ -114,13 +114,13 @@ Use --agent to limit adoption to a specific agent.`,
 
 var agentsStatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Show full health report: store info, detected agents, and link status",
+	Short: "Show store health, detected agents, and link status",
 	RunE:  hook.Wrap("agents.status", runAgentsStatus),
 }
 
 var agentsDiffCmd = &cobra.Command{
 	Use:   "diff",
-	Short: "Show content differences between the canonical store and linked targets",
+	Short: "See what's drifted between your canonical store and agent configs",
 	Long: `Show content differences between the canonical agents store and the linked
 targets. Differences are shown for copy-mode links and paths where a symlink was
 replaced with a regular file or directory.

--- a/cmd/agents_add.go
+++ b/cmd/agents_add.go
@@ -12,7 +12,7 @@ import (
 
 var agentsAddCmd = &cobra.Command{
 	Use:   "add",
-	Short: "Scaffold new content in the canonical agents store",
+	Short: "Add a skill, command, agent, or rule to your store",
 	Long: `Scaffold new content in the canonical agents store.
 
   mine agents add skill <name>     Scaffold a new Agent Skill directory
@@ -34,7 +34,7 @@ var agentsAddCmd = &cobra.Command{
 
 var agentsAddSkillCmd = &cobra.Command{
 	Use:   "skill <name>",
-	Short: "Scaffold a new Agent Skill with SKILL.md and directory structure",
+	Short: "Scaffold a new skill in your agents store",
 	Long: `Scaffold a new Agent Skill in the canonical agents store.
 
 Creates the following structure:
@@ -52,7 +52,7 @@ Name must be lowercase letters, digits, and hyphens (1-64 chars).`,
 
 var agentsAddCommandCmd = &cobra.Command{
 	Use:   "command <name>",
-	Short: "Create a new custom command markdown file",
+	Short: "Add a new custom command to your agents store",
 	Long: `Create a new custom command file in the canonical agents store.
 
 Creates:
@@ -67,7 +67,7 @@ Name must be lowercase letters, digits, and hyphens (1-64 chars).`,
 
 var agentsAddAgentCmd = &cobra.Command{
 	Use:   "agent <name>",
-	Short: "Create a new custom agent definition file",
+	Short: "Add a new agent definition to your store",
 	Long: `Create a new agent definition file in the canonical agents store.
 
 Creates:
@@ -81,7 +81,7 @@ Name must be lowercase letters, digits, and hyphens (1-64 chars).`,
 
 var agentsAddRuleCmd = &cobra.Command{
 	Use:   "rule <name>",
-	Short: "Create a new rule file",
+	Short: "Add a new rule to your agents store",
 	Long: `Create a new rule file in the canonical agents store.
 
 Creates:

--- a/cmd/agents_list.go
+++ b/cmd/agents_list.go
@@ -14,7 +14,7 @@ var agentsListType string
 
 var agentsListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Show a categorized inventory of managed agent configs",
+	Short: "List all managed agent configs in your store",
 	Long: `Show a categorized inventory of managed agent configs in the canonical store.
 
 Lists skills (with descriptions from SKILL.md frontmatter), commands, agent
@@ -41,7 +41,7 @@ func runAgentsList(_ *cobra.Command, _ []string) error {
 	}
 
 	fmt.Println()
-	fmt.Printf("  %s\n", ui.Title.Render("⛏  Agent Configs"))
+	fmt.Printf("  %s\n", ui.Title.Render(ui.IconTools+" Agent Configs"))
 	fmt.Println()
 
 	total := 0

--- a/cmd/agents_project.go
+++ b/cmd/agents_project.go
@@ -20,7 +20,7 @@ var (
 
 var agentsProjectCmd = &cobra.Command{
 	Use:   "project",
-	Short: "Scaffold and link agent configs for a specific project",
+	Short: "Set up and link agent configs for the current project",
 	Long: `Manage project-level agent configurations.
 
   mine agents project init [path]          Scaffold agent config dirs in a project
@@ -31,7 +31,7 @@ var agentsProjectCmd = &cobra.Command{
 
 var agentsProjectInitCmd = &cobra.Command{
 	Use:   "init [path]",
-	Short: "Scaffold project-level agent config directories",
+	Short: "Create agent config directories in the current project",
 	Long: `Scaffold project-level agent configuration directories for all detected agents.
 
 Creates agent config directories (e.g. .claude/, .agents/, .gemini/, .opencode/)
@@ -48,7 +48,7 @@ safe — existing files and directories are preserved unless --force is given.`,
 
 var agentsProjectLinkCmd = &cobra.Command{
 	Use:   "link [path]",
-	Short: "Link canonical agent configs to project-level directories",
+	Short: "Link canonical skills and configs into this project",
 	Long: `Create symlinks (or copies) from the canonical agents store into the
 project-level agent config directories.
 

--- a/cmd/agents_vcs.go
+++ b/cmd/agents_vcs.go
@@ -13,20 +13,20 @@ import (
 
 var agentsCommitCmd = &cobra.Command{
 	Use:   "commit",
-	Short: "Snapshot the current state of the canonical store",
+	Short: "Snapshot your agents store to version history",
 	Long:  `Stage and commit all changes in the canonical store. Initializes git versioning on first use.`,
 	RunE:  hook.Wrap("agents.commit", runAgentsCommit),
 }
 
 var agentsLogCmd = &cobra.Command{
 	Use:   "log [file]",
-	Short: "Show version history of the canonical store",
+	Short: "Browse version history of your agents store",
 	RunE:  hook.Wrap("agents.log", runAgentsLog),
 }
 
 var agentsRestoreCmd = &cobra.Command{
 	Use:   "restore <file>",
-	Short: "Restore an agent config file to a previous version",
+	Short: "Restore an agent config file to a previous snapshot",
 	Long: `Restore a file in the canonical store to a previous snapshot.
 
 The file argument must be a path relative to the canonical store, e.g.:

--- a/cmd/ai.go
+++ b/cmd/ai.go
@@ -21,7 +21,7 @@ import (
 
 var aiCmd = &cobra.Command{
 	Use:   "ai",
-	Short: "AI-powered development helpers",
+	Short: "Your AI co-pilot for code review, commits, and questions",
 	Long:  `Configure AI providers and use AI helpers for code review, commit messages, and quick questions.`,
 	RunE:  hook.Wrap("ai", runAIHelp),
 }
@@ -132,7 +132,7 @@ var (
 
 var aiConfigCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Configure AI provider settings",
+	Short: "Set up your AI provider and API key",
 	Long:  `Set up your AI provider (Claude, OpenAI, etc.) and store your API key securely.`,
 	RunE:  hook.Wrap("ai.config", runAIConfig),
 }
@@ -233,7 +233,7 @@ func runAIConfig(_ *cobra.Command, _ []string) error {
 var (
 	aiAskCmd = &cobra.Command{
 		Use:   "ask <question>",
-		Short: "Ask a quick question",
+		Short: "Ask your AI anything",
 		Long:  `Send a question to your configured AI provider and get an answer.`,
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  hook.Wrap("ai.ask", runAIAsk),
@@ -289,7 +289,7 @@ func runAIAsk(cmd *cobra.Command, args []string) error {
 var (
 	aiReviewCmd = &cobra.Command{
 		Use:   "review",
-		Short: "Review staged changes with AI",
+		Short: "Get AI eyes on your staged changes",
 		Long:  `Get an AI-powered code review of your staged git changes.`,
 		RunE:  hook.Wrap("ai.review", runAIReview),
 	}
@@ -384,7 +384,7 @@ Here's the diff%s:
 // ai commit command
 var aiCommitCmd = &cobra.Command{
 	Use:   "commit",
-	Short: "Generate a commit message from diff",
+	Short: "Let AI draft your commit message",
 	Long:  `Analyze your staged changes and generate a clear commit message.`,
 	RunE:  hook.Wrap("ai.commit", runAICommit),
 }
@@ -645,7 +645,7 @@ func aiVaultProviders() ([]string, error) {
 // ai models command
 var aiModelsCmd = &cobra.Command{
 	Use:   "models",
-	Short: "List available AI providers and models",
+	Short: "See what AI providers and models are available",
 	Long:  `Show configured providers, available providers, and suggested models for each.`,
 	RunE:  hook.Wrap("ai.models", runAIModels),
 }

--- a/cmd/craft.go
+++ b/cmd/craft.go
@@ -63,7 +63,7 @@ func runCraftHelp(_ *cobra.Command, _ []string) error {
 	fmt.Println()
 	fmt.Println(ui.Title.Render("  Craft — build and bootstrap"))
 	fmt.Println()
-	fmt.Println("  Available recipes:")
+	fmt.Println(ui.Muted.Render("  Available recipes:"))
 	fmt.Println()
 	fmt.Printf("    %s   %s\n", ui.Accent.Render("mine craft git"), ui.Muted.Render("Set up git with .gitignore, hooks, etc."))
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -78,7 +78,7 @@ func runReInit(reader *bufio.Reader) error {
 
 	fmt.Println(ui.Title.Render(ui.IconMine + " mine is already set up."))
 	fmt.Println()
-	fmt.Println("  Your current configuration:")
+	fmt.Println(ui.Muted.Render("  Your current configuration:"))
 
 	name := existing.User.Name
 	fmt.Printf("    %-8s %s\n", "Name", ui.Accent.Render(name))

--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -75,7 +75,7 @@ func runMetaHelp(_ *cobra.Command, _ []string) error {
 	fmt.Println()
 	fmt.Println(ui.Title.Render("  Meta — interact with mine itself"))
 	fmt.Println()
-	fmt.Println("  Available commands:")
+	fmt.Println(ui.Muted.Render("  Available commands:"))
 	fmt.Println()
 	fmt.Printf("    %s    %s\n", ui.Accent.Render("mine meta fr <title>"), ui.Muted.Render("Submit a feature request"))
 	fmt.Printf("    %s   %s\n", ui.Accent.Render("mine meta bug <title>"), ui.Muted.Render("Report a bug"))

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -16,7 +16,7 @@ import (
 
 var sshCmd = &cobra.Command{
 	Use:   "ssh",
-	Short: "SSH config management and connection helpers",
+	Short: "Jump to any SSH host, manage keys, and set up tunnels",
 	Long:  `Manage SSH hosts, keys, tunnels, and connections.`,
 	RunE:  hook.Wrap("ssh", runSSH),
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,7 +15,7 @@ BINARY="mine"
 INSTALL_DIR="${HOME}/.local/bin"
 
 main() {
-    echo "⛏  Installing mine..."
+    echo "▸  Installing mine..."
     echo ""
 
     # Detect OS and arch

--- a/site/src/content/docs/commands/agents.md
+++ b/site/src/content/docs/commands/agents.md
@@ -403,7 +403,7 @@ the markdown file.
 **Example output:**
 
 ```
-  ⛏  Agent Configs
+  🔧 Agent Configs
 
   Skills (2):
     code-review       Reviews code changes and provides feedback


### PR DESCRIPTION
## Summary

Full end-to-end resolution of all issues found during `/personality-audit`:

- **Brand violations (ADR-006)**: Replace `⛏` pickaxe icon in `agents_list.go` header and `install.sh` with on-brand alternatives (`ui.IconTools` / `▸`). Update `agents.md` docs to match new output.
- **Flat `agents` command tree**: Warmed up 20 Short descriptions across `agents.*` commands — replaced internal jargon ("canonical store", "persist results to the manifest", "categorized inventory") with developer-friendly voice matching the project's strongest existing examples.
- **Flat `ai` + `ssh` commands**: Warmed up 7 Short descriptions — `aiCmd`, `aiConfigCmd`, `aiAskCmd`, `aiReviewCmd`, `aiCommitCmd`, `aiModelsCmd`, `sshCmd`.
- **Raw fmt fixes**: Applied `ui.Muted.Render()` to 3 bare `fmt.Println` string literals in `init.go`, `craft.go`, and `meta.go`.

## Test plan

- [x] `make test` passes (all tests green)
- [x] `make build` succeeds
- [x] `⛏` no longer appears in any main-branch Go source or shell scripts
- [x] All Short descriptions reviewed against the rubric (warmth, actionable, brand identity)

Closes #N/A (personality audit sweep, no issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)