### PR TITLE
docs: sync STATUS.md — Phase 2 complete

### DIFF
--- a/docs/internal/STATUS.md
+++ b/docs/internal/STATUS.md
@@ -69,7 +69,7 @@ to synergy needs (vault for AI key storage, plugins for extensibility).
 ### Architecture
 
 ```
-818 .go files across 26 packages
+184 .go files across 26 packages
 ├── cmd/            59 files — command layer (thin)
 ├── internal/
 │   ├── agents/     24 files — unified coding agent configuration manager


### PR DESCRIPTION
## Summary

- Marks Phase 2 as fully complete (recurring todos shipped in #234 was the last open item)
- Updates test count to 967 and file count to 184 across 26 packages
- Removes Phase 2 Tail from Remaining Roadmap
- Fixes previously incorrect `.go` file count — worktrees were inflating it (306 → 818 → corrected to 184)

Closes no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)