### PR TITLE
ci: automated release pipeline — Tier 1 (proposal PRs)

### DIFF
--- a/.github/workflows/autodev-release-tag.yml
+++ b/.github/workflows/autodev-release-tag.yml
@@ -27,8 +27,10 @@ jobs:
 
       - name: Extract version from PR title
         id: version
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
+          TITLE="$PR_TITLE"
           echo "PR title: $TITLE"
 
           VERSION=$(echo "$TITLE" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?')

--- a/.github/workflows/autodev-release.yml
+++ b/.github/workflows/autodev-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths-ignore:
+      - "CHANGELOG.md"
       - "docs/internal/coverage.json"
       - "docs/internal/badges.json"
 concurrency:


### PR DESCRIPTION
## Summary

Implements #240 (Tier 1). Adds two workflows that close the last human-in-the-loop gap in the pipeline: release creation.

## New Workflows

### `autodev-release.yml`

Triggers on every push to main (excluding `CHANGELOG.md`, `coverage.json`, `badges.json`). Runs a four-gate check without an agent first:

1. No open `release/proposal` PR already exists
2. A previous tag exists
3. At least 24h since last release (rate limit — prevents release spam)
4. Unreleased `feat:` or `fix:` PRs exist since last tag

If all gates pass, runs a Claude agent (Sonnet 4.6, 30 turns) that:
- Categorizes PRs by conventional commit type
- Proposes a semver bump (minor for any feat, patch for fix-only)
- Updates `CHANGELOG.md` with a versioned section
- Opens a PR titled `chore: release vX.Y.Z` labeled `release/proposal`

**Circuit breakers**: agent writes `SKIP` and skips PR creation for breaking changes, `go.mod`/`go.sum` changes, or unusually large releases (>2000 net LOC) — these still require human `/release`.

### `autodev-release-tag.yml`

Triggers when a `release/proposal` PR is merged to main. Extracts the version from the PR title (`vX.Y.Z` regex), creates an annotated tag, and pushes it using `AUTODEV_TOKEN`. The tag push triggers `release.yml` → GoReleaser → GitHub Release.

## Flow Diagram

```
push to main
    │
    ├── gate-check (no agent) ──→ skip if: proposal exists / no tag / <24h / no feat|fix PRs
    │
    └── draft-release (agent)
            │
            ├── categorize PRs → propose version → update CHANGELOG.md → open PR
            └── circuit breaker → SKIP (breaking change / dep change / huge release)

[human reviews proposal PR]

pull_request merged + release/proposal label
    │
    └── tag-release → extract vX.Y.Z from title → git tag → push → GoReleaser
```

## Acceptance Criteria

Verified against #240:
- [x] Workflow detects unreleased `feat:`/`fix:` PRs since last tag — gate-check step
- [x] Exits cleanly if nothing to release — all four gates checked before agent runs
- [x] Proposes correct semver bump — agent follows release skill logic
- [x] Drafts CHANGELOG entry following existing format — agent updates CHANGELOG.md
- [x] Opens release proposal PR with CHANGELOG.md update — PR creation step
- [x] On proposal PR merge: tag created and pushed — autodev-release-tag.yml
- [x] Rate limit: no proposal PR if last release < 24h — gate 3
- [x] Dedup: no new proposal PR if one is already open — gate 1
- [x] Circuit breaker: breaking changes → SKIP — agent instruction
- [x] Circuit breaker: dependency changes → SKIP — agent instruction
- [x] Circuit breaker: >2000 LOC since last release → SKIP — agent instruction

## Notes

- Tier 2 (full auto-release without PR) tracked separately in #240
- `release/proposal` GitHub label created
- Product sync (auto-running `/product sync` post-release) is a follow-up item

Closes #240 (Tier 1)