### PR TITLE
docs: pipeline health badges and autonomous development README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 > Your personal developer supercharger.
 
+[![CI](https://github.com/rnwolfe/mine/actions/workflows/ci.yml/badge.svg)](https://github.com/rnwolfe/mine/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/rnwolfe/mine/main/docs/internal/badge-coverage.json)](https://github.com/rnwolfe/mine/blob/main/docs/internal/coverage.json)
+[![Release](https://img.shields.io/github/v/release/rnwolfe/mine)](https://github.com/rnwolfe/mine/releases/latest)
+[![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white)](https://go.dev)
+[![License](https://img.shields.io/github/license/rnwolfe/mine)](LICENSE)
+
 A single CLI tool that turbocharges dev velocity, tames environment chaos, and brings a little joy to the terminal. One binary. No runtime dependencies. Some features integrate with tools you already have (git, tmux, ssh).
 
 ## Install
@@ -134,6 +140,15 @@ make dev ARGS="todo"  # quick dev cycle
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full development workflow.
+
+## Autonomous Development
+
+mine is built by an AI-powered development pipeline. When an issue is labeled `backlog/ready`, it's automatically picked up, implemented, reviewed (Copilot + Claude), and merged — no human required until it ships to users.
+
+[![Pipeline Health](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/rnwolfe/mine/main/docs/internal/badge-pipeline-health.json)](https://github.com/rnwolfe/mine/issues?q=label%3Areport%2Fpipeline-audit)
+[![Autodev PRs](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/rnwolfe/mine/main/docs/internal/badge-autodev.json)](https://github.com/rnwolfe/mine/pulls?q=label%3Avia%2Factions+is%3Amerged)
+
+The pipeline implements issues, runs weekly quality sweeps (docs, code health, backlog, personality), and automatically proposes releases when enough features accumulate. See [docs/internal/autodev-pipeline.md](docs/internal/autodev-pipeline.md) for the full architecture.
 
 ## License
 

--- a/docs/internal/badge-autodev.json
+++ b/docs/internal/badge-autodev.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "autodev PRs",
+  "message": "48 merged",
+  "color": "blueviolet"
+}

--- a/docs/internal/badge-coverage.json
+++ b/docs/internal/badge-coverage.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "coverage",
+  "message": "37.5%",
+  "color": "yellow"
+}

--- a/docs/internal/badge-pipeline-health.json
+++ b/docs/internal/badge-pipeline-health.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "pipeline health",
+  "message": "pending",
+  "color": "lightgrey"
+}


### PR DESCRIPTION
## Summary

Implements #246. Adds pipeline health badges to the README and an "Autonomous Development" section explaining how the project is built.

## Changes

### Standard badges (README top)

```markdown
[![CI](CI badge)](CI workflow)
[![Coverage](dynamic from badge-coverage.json)](coverage.json)
[![Release](github release badge)](releases)
[![Go](static Go version badge)](go.dev)
[![License](github license badge)](LICENSE)
```

### Pipeline badges (Autonomous Development section)

```markdown
[![Pipeline Health](dynamic from badge-pipeline-health.json)](audit issues)
[![Autodev PRs](dynamic from badge-autodev.json)](merged autodev PRs)
```

### Badge JSON files

Uses shields.io `/endpoint` format for dynamic color support. Files stored in `docs/internal/`:

| File | Initial value | Updated by |
|------|-------------|-----------|
| `badge-coverage.json` | 37.5% (bootstrap) | coverage-report CI job (#248) |
| `badge-pipeline-health.json` | pending | autodev-audit workflow (#251) |
| `badge-autodev.json` | 48 merged | autodev-audit workflow (#251) |

### Autonomous Development section

Added before License. Explains the autonomous pipeline in 2 sentences and links to the architecture docs. The pipeline health and autodev badges live here, making it a mini-dashboard visible on the GitHub repo homepage.

## Wiring Notes

The badge files are bootstrapped in this PR but auto-update depends on:
- **#248** (coverage reporting): adds badge-coverage.json update to coverage-report job
- **#251** (autodev-audit enhancement): adds badge-pipeline-health.json and badge-autodev.json updates to audit job

Until those PRs merge, badges show initial values. The `paths-ignore` in ci.yml (#248) already includes `docs/internal/badges.json` — a follow-up should extend it to `docs/internal/badge-*.json`.

## Acceptance Criteria

Verified against #246:
- [x] CI status badge in README — standard GitHub Actions badge
- [x] Coverage badge in README — reads from badge-coverage.json
- [x] Latest release badge — GitHub releases API
- [x] Go version badge — static
- [x] License badge — GitHub license detection
- [x] Pipeline health badge — reads from badge-pipeline-health.json
- [x] Autodev PRs merged badge — reads from badge-autodev.json (48 at time of writing)
- [x] `docs/internal/badge-*.json` created with shields.io endpoint schema
- [x] "Autonomous Development" section in README

Closes #246