### PR TITLE
fix: rebase before push in coverage-report to handle concurrent CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
             echo "No coverage changes to commit."
           else
             git commit -m "chore: update coverage report [skip ci]"
+            git pull --rebase origin main
             git push origin main
           fi
 


### PR DESCRIPTION
## Problem

The CI badge is showing failing. Root cause: when multiple pushes hit main in quick succession (e.g., 5 PRs merged back-to-back), multiple `coverage-report` jobs are triggered. Despite `cancel-in-progress: true` in the concurrency group, the surviving job may have already checked out at an older commit. When it commits `coverage.json` and tries to push, main has since moved forward and the push is rejected as non-fast-forward:

```
! [rejected]        main -> main (non-fast-forward)
error: failed to push some refs to 'https://github.com/rnwolfe/mine'
```

## Fix

Add `git pull --rebase origin main` between the commit and push. This rebases the coverage commit on top of whatever is currently at the tip of main before pushing, making it tolerant of concurrent writes.

```diff
  git commit -m "chore: update coverage report [skip ci]"
+ git pull --rebase origin main
  git push origin main
```

## Notes

- The rebase is safe here: the only local change is `docs/internal/coverage.json`, which automated commits never touch concurrently with other content
- `[skip ci]` in the commit message prevents the coverage push from re-triggering CI