### PR TITLE
fix: use GitHub App token in coverage-report for protected branch push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths-ignore:
       - "docs/internal/coverage.json"
+      - "docs/internal/badge-coverage.json"
       - "docs/internal/badges.json"
   pull_request:
     branches: [main]
@@ -126,6 +127,7 @@ jobs:
   coverage-report:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    continue-on-error: true  # Don't fail the CI badge if coverage reporting has issues
     concurrency:
       group: coverage-report-${{ github.ref }}
       cancel-in-progress: true
@@ -134,9 +136,16 @@ jobs:
       contents: write
       issues: write
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.AUTODEV_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Download coverage artifact
@@ -147,14 +156,12 @@ jobs:
           name: coverage-data
           path: /tmp
 
-      - name: Update coverage.json and check regression
+      - name: Update coverage.json and badge, check regression
         if: steps.download.outcome == 'success'
         id: coverage
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 - "${{ github.sha }}" <<'PYEOF'
-          import json, sys
+          python3 <<'PYEOF'
+          import json
           from pathlib import Path
 
           new_data = json.loads(Path("/tmp/coverage-data.json").read_text())
@@ -174,11 +181,17 @@ jobs:
 
           coverage_path.parent.mkdir(parents=True, exist_ok=True)
           coverage_path.write_text(json.dumps(new_data, indent=2) + "\n")
-          print(f"Coverage: {new_data['total_pct']}% ({len(new_data['packages'])} packages)")
+
+          # Update badge-coverage.json with color-coded value
+          pct = new_data["total_pct"]
+          color = "brightgreen" if pct >= 80 else "yellowgreen" if pct >= 60 else "yellow" if pct >= 40 else "orange" if pct >= 20 else "red"
+          badge = {"schemaVersion": 1, "label": "coverage", "message": f"{pct}%", "color": color}
+          Path("docs/internal/badge-coverage.json").write_text(json.dumps(badge, indent=2) + "\n")
+          print(f"Coverage: {pct}% ({len(new_data['packages'])} packages) — badge: {color}")
 
           # Write outputs for subsequent steps
           with open("/tmp/coverage-outputs.env", "w") as f:
-              f.write(f"total={new_data['total_pct']}\n")
+              f.write(f"total={pct}\n")
               f.write(f"regression={'true' if regression else 'false'}\n")
               f.write(f"drop={drop:.1f}\n")
           PYEOF
@@ -188,16 +201,16 @@ jobs:
             echo "$line" >> "$GITHUB_OUTPUT"
           done < /tmp/coverage-outputs.env
 
-      - name: Commit coverage.json
+      - name: Commit coverage data
         if: steps.download.outcome == 'success'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/internal/coverage.json
+          git config user.name "mine-autodev[bot]"
+          git config user.email "mine-autodev[bot]@users.noreply.github.com"
+          git add docs/internal/coverage.json docs/internal/badge-coverage.json
           if git diff --staged --quiet; then
             echo "No coverage changes to commit."
           else
-            git commit -m "chore: update coverage report [skip ci]"
+            git commit -m "chore: update coverage data [skip ci]"
             git pull --rebase origin main
             git push origin main
           fi


### PR DESCRIPTION
Fixes the failing CI badge and stale coverage badge.

## Root cause

The `coverage-report` job was pushing `coverage.json` directly to `main` using `AUTODEV_TOKEN` (a personal PAT). The branch ruleset blocks all direct pushes to `main` — even from PATs associated with an admin account.

## Fix

Use the `mine-autodev` GitHub App installation token (generated via `actions/create-github-app-token@v1`) for checkout and push. The App is on the ruleset bypass list, so the direct push is accepted.

## Also included

- Updates `badge-coverage.json` in the same commit so the README coverage badge shows the real value with color coding (brightgreen ≥80%, yellowgreen ≥60%, yellow ≥40%, orange ≥20%, red <20%)
- `continue-on-error: true` on the job so coverage reporting failures don't fail the CI badge
- `badge-coverage.json` added to push `paths-ignore` to prevent the coverage commit from re-triggering CI