### PR TITLE
feat: wire pipeline health and autodev PR count badges to live data

### DIFF
--- a/.github/workflows/autodev-audit.yml
+++ b/.github/workflows/autodev-audit.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: read
   id-token: write
@@ -21,8 +21,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
 
       # ============================================================
       # AGENT EXECUTION — Provider: Claude via claude-code-action@v1
@@ -241,6 +251,37 @@ jobs:
             --title "Autodev Pipeline Audit — $DATE" \
             --body "$BODY" \
             --label "report/pipeline-audit"
+
+      - name: Update pipeline health badge
+        if: steps.agent.outcome == 'success'
+        run: |
+          SCORE=$(grep -oP '(?<=Health Score: )\d+' /tmp/audit-report.md 2>/dev/null | head -1)
+          if [ -z "$SCORE" ]; then
+            echo "Could not parse health score from report — skipping badge update."
+            exit 0
+          fi
+
+          if [ "$SCORE" -ge 90 ]; then COLOR="brightgreen"
+          elif [ "$SCORE" -ge 70 ]; then COLOR="green"
+          elif [ "$SCORE" -ge 50 ]; then COLOR="yellow"
+          elif [ "$SCORE" -ge 30 ]; then COLOR="orange"
+          else COLOR="red"
+          fi
+
+          printf '{\n  "schemaVersion": 1,\n  "label": "pipeline health",\n  "message": "%s/100",\n  "color": "%s"\n}\n' \
+            "$SCORE" "$COLOR" > docs/internal/badge-pipeline-health.json
+
+          git config user.name "mine-autodev[bot]"
+          git config user.email "mine-autodev[bot]@users.noreply.github.com"
+          git add docs/internal/badge-pipeline-health.json
+          if git diff --staged --quiet; then
+            echo "Badge unchanged — no commit needed."
+          else
+            git commit -m "chore: update pipeline health badge [skip ci]"
+            git pull --rebase origin main
+            git push origin main
+            echo "Pipeline health badge updated: ${SCORE}/100 (${COLOR})"
+          fi
 
       - name: Handle agent failure
         if: steps.agent.outcome == 'failure'

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -648,3 +648,36 @@ jobs:
           gh pr comment "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
             --body "Autodev review pipeline complete. Copilot and Claude reviews have been addressed. ${MERGE_NOTE}"
+
+      - name: Generate App token (badge)
+        id: badge-app-token
+        if: steps.route.outputs.action == 'claude-fix' && (steps.claude-feedback.outputs.no_feedback == 'true' || steps.claude-agent.outcome == 'success')
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Update autodev PR count badge
+        if: steps.route.outputs.action == 'claude-fix' && (steps.claude-feedback.outputs.no_feedback == 'true' || steps.claude-agent.outcome == 'success')
+        env:
+          GH_TOKEN: ${{ steps.badge-app-token.outputs.token }}
+        run: |
+          COUNT=$(gh pr list --repo "${{ github.repository }}" --state merged --limit 500 \
+            --json labels \
+            --jq '[.[] | select(.labels | map(.name) | any(startswith("via/")))] | length')
+
+          FILE_SHA=$(gh api "repos/${{ github.repository }}/contents/docs/internal/badge-autodev.json" \
+            --jq '.sha')
+
+          CONTENT=$(printf '{\n  "schemaVersion": 1,\n  "label": "autodev PRs",\n  "message": "%s merged",\n  "color": "blueviolet"\n}\n' "$COUNT" | base64 -w0)
+
+          gh api "repos/${{ github.repository }}/contents/docs/internal/badge-autodev.json" \
+            -X PUT \
+            -f message="chore: update autodev badge [skip ci]" \
+            -f content="$CONTENT" \
+            -f sha="$FILE_SHA" \
+            -f "committer[name]=mine-autodev[bot]" \
+            -f "committer[email]=mine-autodev[bot]@users.noreply.github.com" \
+            > /dev/null
+
+          echo "Autodev badge updated: ${COUNT} merged"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     paths-ignore:
       - "docs/internal/coverage.json"
       - "docs/internal/badge-coverage.json"
+      - "docs/internal/badge-pipeline-health.json"
+      - "docs/internal/badge-autodev.json"
       - "docs/internal/badges.json"
   pull_request:
     branches: [main]


### PR DESCRIPTION
Both pipeline badges in the README were static placeholders that never updated. This wires them to real data.

## badge-pipeline-health.json

**Updated by**: `autodev-audit.yml` (runs every Monday)

The audit agent already computes a 0–100 health score in its prompt. After the agent completes, a new step parses the score from `/tmp/audit-report.md` and commits `badge-pipeline-health.json` to main via the GitHub App token (bypass). Color scale: brightgreen ≥90, green ≥70, yellow ≥50, orange ≥30, red <30.

Also upgrades the audit workflow's checkout to use the App token (was using default `GITHUB_TOKEN` with `contents: read`).

## badge-autodev.json

**Updated by**: `autodev-review-fix.yml` (after each pipeline completion)

When a PR reaches the `done` phase (Copilot + Claude reviews addressed), a new step counts all merged `via/*` PRs via the GitHub API and updates the badge using the Contents API with the App token. Fresh count on every completion.

## ci.yml

`badge-pipeline-health.json` and `badge-autodev.json` added to push `paths-ignore` so badge commits don't trigger unnecessary CI runs.