### PR TITLE
fix: apply paths-ignore to pull_request trigger as well as push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,17 @@ on:
     paths-ignore:
       - "docs/internal/coverage.json"
       - "docs/internal/badge-coverage.json"
+      - "docs/internal/badge-pipeline-health.json"
+      - "docs/internal/badge-autodev.json"
       - "docs/internal/badges.json"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "docs/internal/coverage.json"
+      - "docs/internal/badge-coverage.json"
+      - "docs/internal/badge-pipeline-health.json"
+      - "docs/internal/badge-autodev.json"
+      - "docs/internal/badges.json"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
CI's `paths-ignore` was only defined under the `push` trigger. GitHub evaluates it per-trigger, so badge-only PRs (e.g. `auto/coverage-*`) still fired a full CI run. Duplicated the ignore list under `pull_request` to fix this. Also adds the two new badge files from #256 while we're here.