### PR TITLE
fix: use fresh App token + Contents API for audit badge update

### DIFF
--- a/.github/workflows/autodev-audit.yml
+++ b/.github/workflows/autodev-audit.yml
@@ -271,24 +271,32 @@ jobs:
           CONTENT=$(printf '{\n  "schemaVersion": 1,\n  "label": "pipeline health",\n  "message": "%s/100",\n  "color": "%s"\n}\n' \
             "$SCORE" "$COLOR" | base64 -w0)
 
-          FILE_SHA=$(gh api "repos/${{ github.repository }}/contents/docs/internal/badge-pipeline-health.json" \
-            --jq '.sha' 2>/dev/null || echo "")
+          MAX_ATTEMPTS=5
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            FILE_SHA=$(gh api "repos/${{ github.repository }}/contents/docs/internal/badge-pipeline-health.json" \
+              --jq '.sha' 2>/dev/null || echo "")
 
-          API_ARGS=(-X PUT
-            -f message="chore: update pipeline health badge [skip ci]"
-            -f content="$CONTENT"
-            -f "committer[name]=mine-autodev[bot]"
-            -f "committer[email]=mine-autodev[bot]@users.noreply.github.com")
-          if [ -n "$FILE_SHA" ]; then
-            API_ARGS+=(-f sha="$FILE_SHA")
-          fi
+            API_ARGS=(-X PUT
+              -f message="chore: update pipeline health badge [skip ci]"
+              -f content="$CONTENT"
+              -f "committer[name]=mine-autodev[bot]"
+              -f "committer[email]=mine-autodev[bot]@users.noreply.github.com")
+            if [ -n "$FILE_SHA" ]; then
+              API_ARGS+=(-f sha="$FILE_SHA")
+            fi
 
-          if gh api "repos/${{ github.repository }}/contents/docs/internal/badge-pipeline-health.json" \
-            "${API_ARGS[@]}" > /dev/null; then
-            echo "Pipeline health badge updated: ${SCORE}/100 (${COLOR})"
-          else
-            echo "::warning::Failed to update pipeline health badge"
-          fi
+            if LAST_ERROR=$(gh api "repos/${{ github.repository }}/contents/docs/internal/badge-pipeline-health.json" \
+              "${API_ARGS[@]}" 2>&1 >/dev/null); then
+              echo "Pipeline health badge updated: ${SCORE}/100 (${COLOR})"
+              break
+            elif [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              DELAY=$(( 2 ** attempt ))
+              echo "Badge update failed on attempt ${attempt} (retrying in ${DELAY}s): ${LAST_ERROR}"
+              sleep "$DELAY"
+            else
+              echo "::warning::Failed to update pipeline health badge after ${MAX_ATTEMPTS} attempts. Last error: ${LAST_ERROR}"
+            fi
+          done
 
       - name: Handle agent failure
         if: steps.agent.outcome == 'failure'


### PR DESCRIPTION
## Root cause

The App token generated at the top of the audit job expires after 1 hour. The agent runs up to 45 minutes, so by the time the badge update step ran the token was stale — git push failed with \"Invalid username or token\".

## Fix

- Generate a fresh App token immediately before the badge update step (not at job start)
- Use the GitHub Contents API instead of git push — same pattern as `autodev-review-fix.yml`, avoids the git remote credential dependency entirely
- Revert the job-level checkout token and `contents: write` permission from #256 — no longer needed since writes go via the API with their own token