### PR TITLE
fix: prevent duplicate review handling and add missing id-token permissions

### DIFF
--- a/.github/workflows/autodev-release.yml
+++ b/.github/workflows/autodev-release.yml
@@ -88,6 +88,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -339,6 +339,14 @@ jobs:
             Your reply should briefly explain what you changed to address the comment.
             If you chose not to change something, explain why.
 
+            IMPORTANT: Do NOT use `gh pr review` to post new reviews on this PR. Only use
+            the inline comment reply API above. The review pipeline manages review state.
+
+            Also: before replying to any comment, check whether you have already replied
+            to it in a previous iteration. The feedback below has been pre-filtered to
+            exclude already-handled comments, but if you see a comment you know you've
+            already addressed, skip it rather than reply again.
+
             ## Review Feedback to Address
 
             ${{ env.REVIEW_FEEDBACK }}
@@ -521,6 +529,14 @@ jobs:
             If you chose not to change something, explain why.
             If you created a follow-up issue instead, include the issue link in your reply.
 
+            IMPORTANT: Do NOT use `gh pr review` to post new reviews on this PR. Only use
+            the inline comment reply API above. The review pipeline manages review state.
+
+            Also: before replying to any comment, check whether you have already replied
+            to it in a previous iteration. The feedback below has been pre-filtered to
+            exclude already-handled comments, but if you see a comment you know you've
+            already addressed, skip it rather than reply again.
+
             ## Review Feedback to Address
 
             ${{ env.REVIEW_FEEDBACK }}
@@ -604,8 +620,8 @@ jobs:
           CURRENT_LABELS=$(gh pr view "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
             --json labels --jq '[.labels[].name]')
-          if echo "$CURRENT_LABELS" | jq -e 'index("human/review-merge")' >/dev/null 2>&1; then
-            echo "PR #$PR_NUMBER already finalized (human/review-merge label present). Skipping duplicate."
+          if echo "$CURRENT_LABELS" | jq -e 'index("human/review-merge") or index("agent/auto-merge")' >/dev/null 2>&1; then
+            echo "PR #$PR_NUMBER already finalized (merge label present). Skipping duplicate."
             exit 0
           fi
 
@@ -622,26 +638,29 @@ jobs:
             --repo "${{ github.repository }}" \
             --body "$UPDATED_BODY"
 
-          # Remove review label and add merge-ready label
-          if ! gh pr edit "$PR_NUMBER" \
-            --repo "${{ github.repository }}" \
-            --remove-label "agent/review-claude" \
-            --add-label "human/review-merge"; then
-            echo "::warning::Failed to update labels on PR #$PR_NUMBER. There may be permission/API issues."
-          fi
-
           # Enable auto-merge — squash-merges as soon as all required CI checks pass.
           # Falls back gracefully if auto-merge is disabled on the repo or the token
           # lacks merge permissions (human can still merge manually).
+          # Label reflects the actual outcome: agent/auto-merge vs human/review-merge.
           if gh pr merge "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
             --squash --auto \
             --delete-branch 2>/dev/null; then
             echo "Auto-merge enabled on PR #$PR_NUMBER — will squash-merge when CI passes."
+            MERGE_LABEL="agent/auto-merge"
             MERGE_NOTE="Auto-merge enabled — will squash-merge once all CI checks pass."
           else
             echo "::warning::Auto-merge could not be enabled on PR #$PR_NUMBER. Human merge required."
+            MERGE_LABEL="human/review-merge"
             MERGE_NOTE="Auto-merge not available — labeled \`human/review-merge\` for manual merge."
+          fi
+
+          # Remove review label and add appropriate merge-state label
+          if ! gh pr edit "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --remove-label "agent/review-claude" \
+            --add-label "$MERGE_LABEL"; then
+            echo "::warning::Failed to update labels on PR #$PR_NUMBER. There may be permission/API issues."
           fi
 
           # Post completion comment

--- a/.github/workflows/backlog-sweep.yml
+++ b/.github/workflows/backlog-sweep.yml
@@ -17,6 +17,7 @@ concurrency:
 
 permissions:
   issues: write
+  id-token: write
 
 jobs:
   sweep:

--- a/.github/workflows/code-sweep.yml
+++ b/.github/workflows/code-sweep.yml
@@ -19,6 +19,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   sweep:

--- a/.github/workflows/doc-sweep.yml
+++ b/.github/workflows/doc-sweep.yml
@@ -19,6 +19,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   sweep:

--- a/.github/workflows/personality-audit.yml
+++ b/.github/workflows/personality-audit.yml
@@ -22,6 +22,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   audit:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,7 +292,8 @@ Phases: `copilot` → `claude` → `done`
 | `agent/review-copilot` | Agent is addressing Copilot review feedback |
 | `agent/review-claude` | Agent is addressing Claude review feedback |
 | `human/blocked` | Agent hit a limit and needs human intervention |
-| `human/review-merge` | All automated reviews done, needs human merge |
+| `agent/auto-merge` | All reviews done, auto-merge enabled — merges when CI passes |
+| `human/review-merge` | All reviews done, auto-merge unavailable — needs human merge |
 
 **Origin labels** (persistent, one per PR):
 
@@ -315,6 +316,7 @@ Phases: `copilot` → `claude` → `done`
 | Label | Meaning |
 |-------|---------|
 | `report/pipeline-audit` | Weekly pipeline health report issue |
+| `regression/autodev` | Bug introduced by an autodev-generated PR — query with `gh issue list --label regression/autodev` to surface in audits |
 
 ### Secrets required
 


### PR DESCRIPTION
## Summary

- Fixes duplicate comment handling in the review pipeline: `parse-reviews.sh` now filters inline comments that Claude has already replied to, preventing the same comment from being addressed across multiple fix iterations
- Fixes five workflows silently failing due to missing `id-token: write` permission (claude-code-action OIDC failure was swallowed by `continue-on-error: true`, causing false-success runs)
- Applies `agent/auto-merge` label when auto-merge is enabled instead of always using `human/review-merge`

## Changes

- **`scripts/autodev/parse-reviews.sh`**: Fetches all inline comments once, extracts IDs already replied to by any `claude*` user via `in_reply_to_id`, and excludes those from the feedback passed to the fix agent
- **`autodev-review-fix.yml`**: Added per-prompt reminder to skip already-handled comments; conditional label logic for auto-merge vs human-merge
- **`claude-code-review.yml`**: Reverted single-review constraint — inline per-file/line comments are kept for reviewer confidence
- **`id-token: write` added to**: `personality-audit.yml`, `code-sweep.yml`, `doc-sweep.yml`, `backlog-sweep.yml`, `autodev-release.yml`
- **`CLAUDE.md`**: Documents `agent/auto-merge` label

## Acceptance Criteria

- [x] Duplicate review comment handling eliminated — comments replied to by Claude are filtered from subsequent fix pass inputs
- [x] `personality-audit.yml` (and 4 other workflows) no longer fail silently on OIDC token error
- [x] Auto-merged PRs get `agent/auto-merge` label; `human/review-merge` only when auto-merge is unavailable

Closes #271 (if exists) or standalone improvement.