### PR TITLE
fix: read copilot_iterations from PR body instead of stale step output

### DIFF
--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -439,7 +439,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --json body --jq '.body')
 
-          COPILOT_ITER="${{ steps.route.outputs.copilot_iterations }}"
+          COPILOT_ITER=$(echo "$PR_BODY" | grep -oP '(?<=<!-- autodev-state: ).*?(?= -->)' | jq -r '.copilot_iterations // 0')
           UPDATED_BODY=$(echo "$PR_BODY" | sed \
             "s/<!-- autodev-state: [^>]* -->/<!-- autodev-state: {\"phase\": \"claude\", \"copilot_iterations\": $COPILOT_ITER} -->/")
 
@@ -630,7 +630,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --json body --jq '.body')
 
-          COPILOT_ITER="${{ steps.route.outputs.copilot_iterations }}"
+          COPILOT_ITER=$(echo "$PR_BODY" | grep -oP '(?<=<!-- autodev-state: ).*?(?= -->)' | jq -r '.copilot_iterations // 0')
           UPDATED_BODY=$(echo "$PR_BODY" | sed \
             "s/<!-- autodev-state: [^>]* -->/<!-- autodev-state: {\"phase\": \"done\", \"copilot_iterations\": $COPILOT_ITER} -->/")
 


### PR DESCRIPTION
## Summary

- Phase transition state writes (Trigger Claude, Finalize/done) were reading `copilot_iterations` from `steps.route.outputs`, captured at run start and never updated mid-run
- Counter was always written as `0` on every phase transition, even after the agent incremented it in the same run
- Both transitions now parse the value from the already-fetched `$PR_BODY`, picking up any increment written earlier in the same run

## Acceptance Criteria

Verified against issue #259:
- [x] `autodev-review-fix` increments `copilot_iterations` in state comment — fixed by reading from live PR body
- [x] Claude phase state write preserves the incremented counter — line 442 fix
- [x] Done phase state write preserves the correct counter — line 633 fix
- [ ] Manual verification: trigger a review-fix run on a test PR to confirm `copilot_iterations: 1` after one fix cycle — requires a live run

## Test plan

- [ ] Trigger a `autodev-review-fix` run on a test PR with Copilot feedback
- [ ] Confirm state comment shows `copilot_iterations: 1` after one fix cycle reaches Claude phase (previously showed `0`)

Fixes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)