### PR TITLE
chore: replace AUTODEV_TOKEN PAT with mine-autodev GitHub App token

### DIFF
--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -33,6 +33,13 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Read issue and prepare branch
         id: prep
         env:
@@ -63,7 +70,7 @@ jobs:
 
       - name: Create branch
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           BRANCH="${{ steps.prep.outputs.branch }}"
           # Delete stale remote branch if it exists (e.g. from a prior closed PR)
@@ -203,7 +210,7 @@ jobs:
       - name: Handle agent failure
         if: steps.agent.outcome == 'failure'
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "::error::Implementation agent failed. No changes were committed."
           echo "::error::See logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -257,7 +264,7 @@ jobs:
       - name: Commit and push
         if: steps.agent.outcome == 'success' && steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -270,7 +277,7 @@ jobs:
         if: steps.agent.outcome == 'success' && steps.changes.outputs.has_changes == 'true'
         id: create-pr
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_URL=$(bash scripts/autodev/open-pr.sh \
             "${{ inputs.issue_number }}" \
@@ -289,7 +296,7 @@ jobs:
       - name: Wait for review and trigger review pipeline
         if: steps.agent.outcome == 'success' && steps.changes.outputs.has_changes == 'true' && steps.create-pr.outputs.pr_number
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUMBER="${{ steps.create-pr.outputs.pr_number }}"
           echo "Waiting for Copilot review on PR #$PR_NUMBER..."
@@ -306,7 +313,7 @@ jobs:
                 -f pr_number="$PR_NUMBER"; then
                 echo "Review-fix pipeline dispatched for PR #$PR_NUMBER."
               else
-                echo "::warning::Failed to dispatch review-fix (AUTODEV_TOKEN needs 'actions: write' permission). The 4-hour scheduled fallback will process this PR."
+                echo "::warning::Failed to dispatch review-fix (app token may lack 'actions: write' permission). The 4-hour scheduled fallback will process this PR."
               fi
               exit 0
             fi
@@ -319,7 +326,7 @@ jobs:
       - name: Handle no changes
         if: steps.agent.outcome == 'success' && steps.changes.outputs.has_changes == 'false'
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # Read agent blocker report if it exists
           BLOCKER_MSG=""

--- a/.github/workflows/autodev-release.yml
+++ b/.github/workflows/autodev-release.yml
@@ -90,9 +90,16 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.AUTODEV_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       # ============================================================
@@ -161,7 +168,7 @@ jobs:
       - name: Create release proposal PR
         if: steps.agent.outcome == 'success'
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [ ! -f /tmp/release-version.txt ]; then
             echo "::warning::Agent did not produce /tmp/release-version.txt — skipping"

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -244,6 +244,15 @@ jobs:
           echo "Unknown phase: $PHASE. Skipping."
           echo "action=skip" >> "$GITHUB_OUTPUT"
 
+      # ── Generate app token (shared by all non-skip paths) ─────────
+      - name: Generate app token
+        id: app-token
+        if: steps.route.outputs.action != 'skip'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       # ── Checkout (shared by all fix paths) ────────────────────────
       - name: Checkout PR branch
         if: steps.route.outputs.action != 'skip'
@@ -251,7 +260,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_review' && github.event.pull_request.head.ref || '' }}
           fetch-depth: 0
-          token: ${{ secrets.AUTODEV_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Resolve PR branch for non-review events
         if: steps.route.outputs.action != 'skip' && github.event_name != 'pull_request_review'
@@ -356,7 +365,7 @@ jobs:
       - name: Handle agent failure (copilot fix)
         if: steps.route.outputs.action == 'copilot-fix' && steps.copilot-feedback.outputs.override_action != 'trigger-claude' && steps.copilot-agent.outcome == 'failure'
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "::error::Copilot fix agent failed (outcome: ${{ steps.copilot-agent.outcome }}). No changes were committed."
           echo "::error::See logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -389,7 +398,7 @@ jobs:
       - name: Commit and push (copilot fix)
         if: steps.route.outputs.action == 'copilot-fix' && steps.copilot-feedback.outputs.override_action != 'trigger-claude' && steps.copilot-agent.outcome == 'success' && steps.copilot-changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           NEXT_ITER=$(( ${{ steps.route.outputs.copilot_iterations }} + 1 ))
           git config user.name "github-actions[bot]"
@@ -432,7 +441,7 @@ jobs:
           || steps.copilot-feedback.outputs.override_action == 'trigger-claude'
           || (steps.route.outputs.action == 'copilot-fix' && steps.copilot-feedback.outputs.override_action != 'trigger-claude' && steps.copilot-agent.outcome == 'success')
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # Update phase in PR body
           PR_BODY=$(gh pr view "${{ steps.route.outputs.pr_number }}" \
@@ -546,7 +555,7 @@ jobs:
       - name: Handle agent failure (claude fix)
         if: steps.route.outputs.action == 'claude-fix' && steps.claude-feedback.outputs.no_feedback != 'true' && steps.claude-agent.outcome == 'failure'
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "::error::Claude fix agent failed (outcome: ${{ steps.claude-agent.outcome }}). No changes were committed."
           echo "::error::See logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -579,7 +588,7 @@ jobs:
       - name: Commit and push (claude fix)
         if: steps.route.outputs.action == 'claude-fix' && steps.claude-feedback.outputs.no_feedback != 'true' && steps.claude-agent.outcome == 'success' && steps.claude-changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -591,7 +600,7 @@ jobs:
       - name: Dismiss CHANGES_REQUESTED reviews (claude fix)
         if: steps.route.outputs.action == 'claude-fix' && (steps.claude-feedback.outputs.no_feedback == 'true' || steps.claude-agent.outcome == 'success')
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUMBER="${{ steps.route.outputs.pr_number }}"
           # Dismiss any outstanding CHANGES_REQUESTED reviews from claude[bot].
@@ -610,7 +619,7 @@ jobs:
       - name: Finalize — mark phase done
         if: steps.route.outputs.action == 'claude-fix' && (steps.claude-feedback.outputs.no_feedback == 'true' || steps.claude-agent.outcome == 'success')
         env:
-          GH_TOKEN: ${{ secrets.AUTODEV_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUMBER="${{ steps.route.outputs.pr_number }}"
 


### PR DESCRIPTION
## Summary

Moves all autodev pipeline actions from running under the personal `AUTODEV_TOKEN` PAT to the `mine-autodev` GitHub App identity. Token is generated per-run via `actions/create-github-app-token@v1` using the existing `APP_ID` / `APP_PRIVATE_KEY` secrets (already in use for the badge update step).

- Actions in audit log now appear as `mine-autodev[bot]` instead of `rnwolfe`
- No more PAT expiry/rotation burden
- Clean identity separation between human and autonomous pipeline work

## Changes

- **autodev-implement.yml**: Added `Generate app token` step after Setup Go; replaced all `AUTODEV_TOKEN` env refs; updated stale warning message
- **autodev-review-fix.yml**: Added `Generate app token` step before Checkout (after Determine action); replaced `token:` field on checkout and all `GH_TOKEN:` env refs
- **autodev-release.yml**: Added `Generate app token` step at start of `draft-release` job; replaced `token:` field on checkout and `GH_TOKEN:` on PR creation step

## Prerequisites

The `mine-autodev` GitHub App must have these permissions configured on the repo:
- Contents: read/write
- Pull requests: read/write
- Issues: read/write
- Actions: read/write (workflow dispatch)
- Metadata: read

🤖 Generated with [Claude Code](https://claude.com/claude-code)