### PR TITLE
fix: add mine-autodev to allowed_bots in review-fix agent steps

### DIFF
--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -331,7 +331,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "github-actions[bot],claude"
+          allowed_bots: "github-actions[bot],claude,mine-autodev,mine-autodev[bot]"
           prompt: |
             You are fixing Copilot review feedback on PR #${{ steps.route.outputs.pr_number }} for the mine CLI tool.
 
@@ -514,7 +514,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "github-actions[bot],claude"
+          allowed_bots: "github-actions[bot],claude,mine-autodev,mine-autodev[bot]"
           prompt: |
             You are doing a final review-fix pass on PR #${{ steps.route.outputs.pr_number }} for the mine CLI tool.
             This is the last automated fix cycle — make it count.


### PR DESCRIPTION
## Summary

Same `allowed_bots` issue as #297, but in the `autodev-review-fix.yml` agent steps. The `copilot-fix` and `claude-fix` claude-code-action steps were rejecting runs initiated by `mine-autodev[bot]`, which is the actor for any `workflow_run`-triggered review-fix run (because the upstream Claude Code Review was itself triggered by a label the bot added).

Discovered while watching PR #299 execute: the claude-fix agent failed immediately with "Workflow initiated by non-human actor: mine-autodev" adding `human/blocked` to the PR.

## Changes

- **`.github/workflows/autodev-review-fix.yml`** — add `mine-autodev,mine-autodev[bot]` to `allowed_bots` on both the `Run agent (copilot fix)` and `Run agent (claude fix)` steps

## Related

- Companion to #297 which fixed the same issue in `claude-code-review.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)