### PR TITLE
fix: never skip Copilot review phase when no review found

### DIFF
--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -130,8 +130,15 @@ jobs:
 
             if [ -z "$LATEST_REVIEW" ] || [ "$LATEST_REVIEW" = "null" ]; then
               if [ "$PHASE" = "copilot" ]; then
-                echo "No Copilot review found on PR #$PR_NUMBER — Copilot did not review within polling window. Transitioning to Claude phase."
-                echo "action=trigger-claude" >> "$GITHUB_OUTPUT"
+                # Copilot hasn't reviewed yet — re-request in case the initial request was missed,
+                # then wait. Never skip Copilot review entirely: Copilot always reviews first,
+                # even if they have no comments (LGTM). Transition to Claude only after Copilot
+                # has actually posted a review. The 4-hour scheduled poll will check again.
+                echo "No Copilot review found on PR #$PR_NUMBER. Re-requesting Copilot review and waiting..."
+                gh api -X POST \
+                  "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
+                  -f 'reviewers[]=copilot-pull-request-reviewer' 2>/dev/null || true
+                echo "action=skip" >> "$GITHUB_OUTPUT"
               else
                 echo "No reviews found on PR #$PR_NUMBER in phase '$PHASE'. Skipping."
                 echo "action=skip" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

When `autodev-review-fix` was dispatched/scheduled and Copilot hadn't reviewed yet, the pipeline immediately transitioned to Claude phase — skipping Copilot entirely. This violated the pipeline invariant that every autodev PR gets **both** a Copilot and Claude review (even if Copilot has no comments).

## Changes

- **Modified**: `.github/workflows/autodev-review-fix.yml` — `Determine action` step: when copilot phase and no review found, re-request Copilot reviewer (in case the initial request was missed) and `action=skip` instead of `action=trigger-claude`

## Behavior After Fix

| Scenario | Before | After |
|----------|--------|-------|
| Dispatch, copilot phase, no review yet | Skip Copilot → Claude | Re-request Copilot, wait |
| Dispatch, copilot phase, Copilot reviewed with comments | copilot-fix | copilot-fix (unchanged) |
| Dispatch, copilot phase, Copilot reviewed with no comments | trigger-claude | trigger-claude (unchanged) |
| pull_request_review from Copilot with comments | copilot-fix | copilot-fix (unchanged) |
| pull_request_review from Copilot with no comments | trigger-claude | trigger-claude (unchanged) |

The 4-hour scheduled poll now acts as the "check back once Copilot has reviewed" mechanism rather than the "fall through to Claude" mechanism.

## Root Cause

`open-pr.sh` previously failed silently when requesting Copilot as reviewer (wrong login format). That bug was fixed in #297. This PR fixes the downstream behavior that treated "no review" as a signal to skip Copilot, rather than a signal to wait.