### PR TITLE
ci: add error handling rules to agent prompts and Copilot review instructions

### DIFF
--- a/.github/instructions/copilot-review.instructions.md
+++ b/.github/instructions/copilot-review.instructions.md
@@ -1,0 +1,43 @@
+# Copilot Review Instructions for mine
+
+## Project Context
+
+mine is a Go CLI tool built with Cobra, Lipgloss/Bubbletea TUI, and SQLite (modernc.org/sqlite, pure Go). Single binary, no CGo.
+
+## File Size Limit
+
+All non-test Go files under `cmd/` and `internal/` must stay under 500 lines. Flag any file exceeding this limit. Known exceptions are tracked in `.github/filelen-exceptions.txt`.
+
+## Error Handling (Priority: High)
+
+This is the most frequent review feedback category. Flag these patterns:
+
+- **Silent error ignoring**: Any `err` from a database query, I/O operation, or HTTP call that is discarded (assigned to `_` or unchecked). Errors from `sql.Query`, `sql.QueryRow().Scan()`, `sql.Exec`, `os.Open`, `os.ReadFile`, `json.Marshal/Unmarshal`, etc. must be checked.
+- **Catch-all error masking**: Using any `err != nil` as "no rows found". The correct pattern is to check `errors.Is(err, sql.ErrNoRows)` specifically and return/wrap all other errors.
+- **Partial failure coupling**: When a function performs multiple independent operations (e.g., querying streak AND querying total minutes), one failure should not prevent the other from succeeding. Flag code where a single `if err != nil { return }` blocks unrelated data.
+- **Missing error wrapping**: Bare `return err` without context. Prefer `fmt.Errorf("operation context: %w", err)`.
+
+## Store Pattern
+
+Each feature domain has a package under `internal/` with a `Store` type that owns all SQL. The `cmd/` layer should never contain raw SQL queries — it calls store methods. Flag any `db.Query`, `db.Exec`, or `db.QueryRow` in `cmd/*.go` files.
+
+## UI Output
+
+All user-facing output must use helpers from `internal/ui` (`ui.Ok`, `ui.Warn`, `ui.Err`, `ui.Tip`, `ui.Kv`, `ui.Accent.Render()`). Flag any raw `fmt.Println` or `fmt.Printf` that produces user-facing output in `cmd/` files. Error messages should include what went wrong AND what to do about it.
+
+## Testing Standards
+
+- Tests use `t.TempDir()` + `t.Setenv()` for isolation — never touch the real filesystem.
+- Integration tests should call the actual `runXxx` handler, not just internal helpers.
+- External tool tests (tmux, git, editors) should mock via fake scripts in `t.TempDir()` on `$PATH`.
+- When tests modify package-level global variables (e.g., Cobra flag vars), they should restore them via `t.Cleanup`.
+
+## Hook Wrapping
+
+All command handlers should be wrapped with `hook.Wrap("command.name", handlerFunc)` to participate in the plugin pipeline. Flag any `RunE` that directly assigns a handler without `hook.Wrap`.
+
+## Code Style
+
+- `cmd/` files are thin orchestration: parse args, call domain logic, format output.
+- `internal/` packages own their domain and don't import each other unnecessarily.
+- Emoji in output must use icon constants from `internal/ui/theme.go` — no raw emoji literals.

--- a/.github/workflows/autodev-implement.yml
+++ b/.github/workflows/autodev-implement.yml
@@ -111,6 +111,16 @@ jobs:
               - site/src/content/docs/getting-started/quick-start.md (onboarding examples)
               - site/src/content/docs/index.mdx (top-level docs landing and high-level feature claims)
             - Write tests for new functionality
+            - ERROR HANDLING — The #1 recurring review feedback theme. Follow these rules:
+              - Never silently ignore errors from database queries or I/O operations
+              - Use `sql.ErrNoRows` for expected missing-data cases; wrap and return all other errors
+              - If a function can partially succeed, handle each error independently — don't let
+                one failure block unrelated data (e.g., streak query failing shouldn't prevent
+                total-minutes from being set)
+              - Never mask real database errors behind catch-all fallbacks (e.g., don't treat
+                any SELECT error as "no rows" — check `sql.ErrNoRows` specifically)
+              - In shell scripts, derive/assign variables before using them; never reference
+                a variable before the line that sets it
             - QUALITY GATE — Before committing, verify:
               - If the issue references a file pattern to follow, you have read it and matched it
               - Integration tests call the actual runXxx handler, not just helper functions

--- a/.github/workflows/autodev-review-fix.yml
+++ b/.github/workflows/autodev-review-fix.yml
@@ -349,6 +349,10 @@ jobs:
             - Do NOT modify CLAUDE.md, any files in .github/workflows/, or scripts/autodev/
             - You CAN and SHOULD update docs/internal/lessons-learned.md (append new L-NNN entries)
               and docs/internal/key-files.md when your changes warrant it
+            - ERROR HANDLING — common review feedback theme. When fixing or writing code:
+              - Never silently ignore errors from database queries or I/O operations
+              - Use `sql.ErrNoRows` for expected missing-data cases; wrap and return all other errors
+              - Handle partial failures independently — one query failing shouldn't block unrelated data
             - Address ALL review comments below
             - If a comment is unclear, make your best judgment
 
@@ -533,6 +537,10 @@ jobs:
             - Do NOT modify CLAUDE.md, any files in .github/workflows/, or scripts/autodev/
             - You CAN and SHOULD update docs/internal/lessons-learned.md (append new L-NNN entries)
               and docs/internal/key-files.md when your changes warrant it
+            - ERROR HANDLING — common review feedback theme. When fixing or writing code:
+              - Never silently ignore errors from database queries or I/O operations
+              - Use `sql.ErrNoRows` for expected missing-data cases; wrap and return all other errors
+              - Handle partial failures independently — one query failing shouldn't block unrelated data
             - Address ALL review comments below
             - For anything that CANNOT be fully resolved in this PR, create a follow-up
               GitHub issue using `gh issue create` with:


### PR DESCRIPTION
## Summary

Pipeline audit of the last 20 autodev PRs found that **error handling** is the #1 recurring review feedback theme — Copilot flagged it in 4 separate PRs (#295, #296, #268, #303). This PR adds explicit error handling rules to all three agent prompts and creates a Copilot custom instructions file so Copilot reviews with full project context.

## Changes

- **Modified**: `.github/workflows/autodev-implement.yml` — Added ERROR HANDLING section to the implement agent prompt with 5 specific rules (silent error ignoring, `sql.ErrNoRows` vs catch-all, partial failure independence, error masking, shell variable ordering)
- **Modified**: `.github/workflows/autodev-review-fix.yml` — Added ERROR HANDLING section to both the copilot-fix and claude-fix agent prompts (3 key rules each)
- **New file**: `.github/instructions/copilot-review.instructions.md` — Copilot custom instructions covering: file size limit, error handling patterns, store pattern (no SQL in cmd/), UI output helpers, testing standards, hook wrapping, and code style conventions

## Acceptance Criteria

- [x] Error handling rules added to implement agent prompt — 5 rules covering the specific patterns Copilot has been catching
- [x] Error handling rules added to copilot-fix agent prompt — 3 key rules
- [x] Error handling rules added to claude-fix agent prompt — 3 key rules
- [x] Copilot custom instructions created — covers all major project conventions that Copilot should enforce during review
- [x] No functional changes to pipeline logic — prompt-only additions

## Test Plan

- [ ] Verify next autodev PR gets reviewed by Copilot with project-specific context (check if Copilot references the instructions)
- [ ] Monitor next 5 autodev PRs for reduction in error handling feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)